### PR TITLE
chore: fix lint issues across all services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Two-layer model:
 - **Python 3.14+** and **UV** — see `.github/instructions/python.instructions.md` for full conventions.
   Critical rule: always `uv run <cmd>`, never call `python`/`pip`/`pytest` directly.
 - **Docker Compose** — 7 split files orchestrated via `Makefile`
-- **Ruff** — linting, line-length=100, rules: E, F, W, I (configured in root `pyproject.toml`)
+- **Ruff** — linting, line-length=200, rules: E, F, W, I (configured in root `pyproject.toml`)
 - **Black** — formatting (`uvx ruff check <project>` / `uv run black <project>`)
 - **Pyright** — type checking
 

--- a/agent-logs/agent_logs/logs_analyzer.py
+++ b/agent-logs/agent_logs/logs_analyzer.py
@@ -43,9 +43,7 @@ class LogsAnalyzer:
             self.llm = get_llm()
             logger.info("LLM initialized for logs analysis")
         except Exception as e:
-            logger.warning(
-                f"LLM not available, using basic analysis: {e}", exc_info=True
-            )
+            logger.warning(f"LLM not available, using basic analysis: {e}", exc_info=True)
             self.llm = None
 
     async def close(self):
@@ -76,9 +74,7 @@ class LogsAnalyzer:
         logger.info(f"Analyzing logs for query: {query}")
 
         if not self.llm:
-            raise RuntimeError(
-                "LLM unavailable; cannot analyze logs without LLM per configuration"
-            )
+            raise RuntimeError("LLM unavailable; cannot analyze logs without LLM per configuration")
 
         # Use LLM to build better LogQL query if available
         logql_query = await self._build_logql_query_with_llm(query, context)
@@ -109,9 +105,7 @@ class LogsAnalyzer:
         #     }
 
         # Always analyze with LLM (no hardcoded responses)
-        analysis = await self._analyze_logs_with_llm(
-            logs_data, query, context, time_range
-        )
+        analysis = await self._analyze_logs_with_llm(logs_data, query, context, time_range)
 
         return {
             "agent_name": "logs",
@@ -122,7 +116,6 @@ class LogsAnalyzer:
             "grafana_links": self._generate_grafana_links(logql_query, time_range),
             "timestamp": datetime.now().isoformat(),
         }
-
 
     def _build_logql_query(self, query: str, context: dict[str, Any]) -> str:
         """
@@ -171,9 +164,7 @@ class LogsAnalyzer:
         logger.info(f"Querying Loki with: {logql}")
 
         # Query via MCP client
-        result = await self.mcp_client.query_logs(
-            query=logql, time_range=time_range, limit=100
-        )
+        result = await self.mcp_client.query_logs(query=logql, time_range=time_range, limit=100)
 
         # Return in expected format
         if "error" in result:
@@ -210,17 +201,9 @@ class LogsAnalyzer:
         for log in logs:
             # Extract from labels (MCP Grafana format) or fallback to direct fields
             labels = log.get("labels", {})
-            message = (
-                log.get("line", "") or
-                log.get("message", "") or
-                log.get("msg", "")
-            )
+            message = log.get("line", "") or log.get("message", "") or log.get("msg", "")
             service = labels.get("service_name", log.get("service_name", "unknown"))
-            level = (
-                labels.get("severity_text", "") or
-                log.get("level", "") or
-                log.get("severity", "")
-            ).upper()
+            level = (labels.get("severity_text", "") or log.get("level", "") or log.get("severity", "")).upper()
 
             is_error = False
             if level in ("ERROR", "CRITICAL"):
@@ -234,37 +217,21 @@ class LogsAnalyzer:
                 affected_services.add(service)
 
         # Build error types list sorted by count
-        error_types_list = [
-            {"type": error_type, "count": count}
-            for error_type, count in sorted(
-                error_types.items(), key=lambda x: x[1], reverse=True
-            )
-        ]
+        error_types_list = [{"type": error_type, "count": count} for error_type, count in sorted(error_types.items(), key=lambda x: x[1], reverse=True)]
 
         time_range_checked = context.get("time_range", "1h")
-        summary_parts = [
-            f"Found {error_count} error logs in the last {time_range_checked}."
-        ]
+        summary_parts = [f"Found {error_count} error logs in the last {time_range_checked}."]
 
         if error_types_list:
             primary_error = error_types_list[0]
-            summary_parts.append(
-                f"Primary error: '{primary_error['type']}' ({primary_error['count']} occurrences)."
-            )
+            summary_parts.append(f"Primary error: '{primary_error['type']}' ({primary_error['count']} occurrences).")
 
         simulated_markers = ("simulated", "error_rate")
-        has_simulated_errors = any(
-            any(marker in error_type.lower() for marker in simulated_markers)
-            for error_type in error_types
-        )
+        has_simulated_errors = any(any(marker in error_type.lower() for marker in simulated_markers) for error_type in error_types)
         if has_simulated_errors:
-            summary_parts.append(
-                "Note: Some errors appear to be simulated (ERROR_RATE environment variable)."
-            )
+            summary_parts.append("Note: Some errors appear to be simulated (ERROR_RATE environment variable).")
 
-        summary_parts.append(
-            f"Affected services: {', '.join(sorted(affected_services))}."
-        )
+        summary_parts.append(f"Affected services: {', '.join(sorted(affected_services))}.")
 
         # Generate simple recommendations based on error count
         recommendations = []
@@ -304,9 +271,7 @@ class LogsAnalyzer:
         base_url = "http://grafana:3000/explore"
         return [f"{base_url}?query={logql}&range={time_range}"]
 
-    async def _build_logql_query_with_llm(
-        self, query: str, context: dict[str, Any]
-    ) -> str:
+    async def _build_logql_query_with_llm(self, query: str, context: dict[str, Any]) -> str:
         """
         Use LLM to build an optimized LogQL query from prompt template
 
@@ -318,11 +283,7 @@ class LogsAnalyzer:
             LogQL query string
         """
         services = context.get("services", [])
-        services_context = (
-            f"Available services: {', '.join(services)}"
-            if services
-            else "No specific services mentioned"
-        )
+        services_context = f"Available services: {', '.join(services)}" if services else "No specific services mentioned"
 
         # Load prompt template from markdown file
         prompt_template = load_prompt("build_logql.md")
@@ -331,9 +292,7 @@ class LogsAnalyzer:
 
         # Replace variables in template
         try:
-            prompt = prompt_template.format(
-                query=query, services_context=services_context
-            )
+            prompt = prompt_template.format(query=query, services_context=services_context)
         except KeyError as e:
             logger.error(f"Missing variable in build_logql.md template: {e}")
             raise RuntimeError("Invalid build_logql.md prompt template") from e
@@ -413,11 +372,7 @@ class LogsAnalyzer:
             service = labels.get("service_name", log.get("service_name", "unknown"))
 
             # Try to get message from various possible fields
-            message = (
-                log.get("line", "") or
-                log.get("message", "") or
-                log.get("msg", "")
-            )
+            message = log.get("line", "") or log.get("message", "") or log.get("msg", "")
 
             if isinstance(message, str):
                 message = message[:200].strip()
@@ -445,9 +400,7 @@ class LogsAnalyzer:
                 time_range=time_range,
                 services=services_str,
                 total_logs=total_logs,
-                log_samples=(
-                    "\n".join(log_samples_text) if log_samples_text else "No logs found"
-                ),
+                log_samples=("\n".join(log_samples_text) if log_samples_text else "No logs found"),
             )
         except KeyError as e:
             logger.error(f"Missing variable in analyze_logs.md template: {e}")
@@ -514,16 +467,10 @@ class LogsAnalyzer:
                         "confidence": 0.95 if error_count > 0 else 0.3,
                     }
                 except Exception:
-                    logger.warning(
-                        "Failed to parse JSON from LLM response, falling back"
-                    )
+                    logger.warning("Failed to parse JSON from LLM response, falling back")
 
             # If logs empty and user asked for short window, return structured fallback
-            if total_logs == 0 and (
-                "5m" in time_range
-                or "5" in time_range
-                or "5 minutes" in prompt.lower()
-            ):
+            if total_logs == 0 and ("5m" in time_range or "5" in time_range or "5 minutes" in prompt.lower()):
                 return {
                     "summary": f"No logs available for the last {time_range}.",
                     "data": {

--- a/agent-logs/agent_logs/main.py
+++ b/agent-logs/agent_logs/main.py
@@ -30,9 +30,7 @@ async def lifespan(app: FastAPI):
     global analyzer
     # Startup
     logger.info("Logs Agent starting up...")
-    logger.info(
-        f"MCP Grafana URL: {os.getenv('MCP_GRAFANA_URL', 'http://grafana-mcp:8000')}"
-    )
+    logger.info(f"MCP Grafana URL: {os.getenv('MCP_GRAFANA_URL', 'http://grafana-mcp:8000')}")
     analyzer = LogsAnalyzer()
     yield
     # Shutdown

--- a/agent-metrics/agent_metrics/main.py
+++ b/agent-metrics/agent_metrics/main.py
@@ -30,9 +30,7 @@ async def lifespan(app: FastAPI):
     global analyzer
     # Startup
     logger.info("Metrics Agent starting up...")
-    logger.info(
-        f"MCP Grafana URL: {os.getenv('MCP_GRAFANA_URL', 'http://grafana-mcp:8000')}"
-    )
+    logger.info(f"MCP Grafana URL: {os.getenv('MCP_GRAFANA_URL', 'http://grafana-mcp:8000')}")
     analyzer = MetricsAnalyzer()
     yield
     # Shutdown

--- a/agent-metrics/agent_metrics/metrics_analyzer.py
+++ b/agent-metrics/agent_metrics/metrics_analyzer.py
@@ -87,9 +87,7 @@ class MetricsAnalyzer:
 
         # Analyze metrics data with LLM if available
         if self.llm and metrics_data:
-            analysis = await self._analyze_metrics_with_llm(
-                metrics_data, query, context, time_range
-            )
+            analysis = await self._analyze_metrics_with_llm(metrics_data, query, context, time_range)
         else:
             analysis = self._analyze_metrics(metrics_data, query, context)
 
@@ -98,9 +96,7 @@ class MetricsAnalyzer:
             "analysis": analysis["summary"],
             "data": analysis["data"],
             "confidence": analysis["confidence"],
-            "grafana_links": self._generate_grafana_links(
-                promql_queries[0] if promql_queries else "", time_range
-            ),
+            "grafana_links": self._generate_grafana_links(promql_queries[0] if promql_queries else "", time_range),
             "timestamp": datetime.now().isoformat(),
         }
 
@@ -127,19 +123,11 @@ class MetricsAnalyzer:
 
         # Error rate query
         if "error" in query_lower or "fail" in query_lower:
-            queries.append(
-                f'rate(http_requests_total{{status=~"5..", {service_filter}}}[5m])'
-            )
+            queries.append(f'rate(http_requests_total{{status=~"5..", {service_filter}}}[5m])')
 
         # Latency query
-        if (
-            "slow" in query_lower
-            or "latency" in query_lower
-            or "performance" in query_lower
-        ):
-            queries.append(
-                f"histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{{{service_filter}}}[5m]))"
-            )
+        if "slow" in query_lower or "latency" in query_lower or "performance" in query_lower:
+            queries.append(f"histogram_quantile(0.95, rate(http_request_duration_seconds_bucket{{{service_filter}}}[5m]))")
 
         # Request rate query
         if "request" in query_lower or "traffic" in query_lower:
@@ -147,15 +135,11 @@ class MetricsAnalyzer:
 
         # CPU usage query
         if "cpu" in query_lower or "resource" in query_lower:
-            queries.append(
-                f"avg(rate(process_cpu_seconds_total{{{service_filter}}}[5m])) * 100"
-            )
+            queries.append(f"avg(rate(process_cpu_seconds_total{{{service_filter}}}[5m])) * 100")
 
         # Memory usage query
         if "memory" in query_lower or "resource" in query_lower:
-            queries.append(
-                f"process_resident_memory_bytes{{{service_filter}}} / 1024 / 1024"
-            )
+            queries.append(f"process_resident_memory_bytes{{{service_filter}}} / 1024 / 1024")
 
         # Default: error rate and request rate
         if not queries:
@@ -168,9 +152,7 @@ class MetricsAnalyzer:
 
         return queries
 
-    async def _query_mimir(
-        self, promql_queries: list[str], time_range: str
-    ) -> dict[str, Any]:
+    async def _query_mimir(self, promql_queries: list[str], time_range: str) -> dict[str, Any]:
         """
         Query Mimir via MCP Grafana
 
@@ -186,9 +168,7 @@ class MetricsAnalyzer:
         # Query each PromQL expression via MCP client
         results = {}
         for i, promql in enumerate(promql_queries):
-            result = await self.mcp_client.query_metrics(
-                query=promql, time_range=time_range
-            )
+            result = await self.mcp_client.query_metrics(query=promql, time_range=time_range)
 
             if "error" not in result:
                 # Map results to expected keys based on query type
@@ -278,24 +258,16 @@ class MetricsAnalyzer:
         service_name = services[0] if services else "services"
 
         if error_rate > 0:
-            summary_parts.append(
-                f"{service_name} shows {error_rate*100:.1f}% HTTP 500 error rate "
-                f"(expected: <1%). This indicates reliability issues."
-            )
+            summary_parts.append(f"{service_name} shows {error_rate * 100:.1f}% HTTP 500 error rate (expected: <1%). This indicates reliability issues.")
 
         if latency_p95 > 0:
-            summary_parts.append(
-                f"Request latency p95: {latency_p95}ms "
-                f"({'above' if latency_p95 > 200 else 'within'} baseline of 200ms)."
-            )
+            summary_parts.append(f"Request latency p95: {latency_p95}ms ({'above' if latency_p95 > 200 else 'within'} baseline of 200ms).")
 
         if request_rate > 0:
             summary_parts.append(f"Current request rate: {request_rate:.1f} req/s.")
 
         if anomalies:
-            summary_parts.append(
-                f"Detected {len(anomalies)} anomal{'ies' if len(anomalies) > 1 else 'y'} requiring attention."
-            )
+            summary_parts.append(f"Detected {len(anomalies)} anomal{'ies' if len(anomalies) > 1 else 'y'} requiring attention.")
         else:
             summary_parts.append("No significant anomalies detected.")
 
@@ -344,13 +316,9 @@ class MetricsAnalyzer:
         # Prepare anomalies text (simple formatting, no logic)
         anomalies_text = []
         if error_rate > 0.05:
-            anomalies_text.append(
-                f"- Error rate: {error_rate*100:.1f}% (threshold: <5%)"
-            )
+            anomalies_text.append(f"- Error rate: {error_rate * 100:.1f}% (threshold: <5%)")
         if latency_p95 > 200:
-            anomalies_text.append(
-                f"- Latency P95: {latency_p95:.0f}ms (threshold: <200ms)"
-            )
+            anomalies_text.append(f"- Latency P95: {latency_p95:.0f}ms (threshold: <200ms)")
         if cpu_usage > 80:
             anomalies_text.append(f"- CPU usage: {cpu_usage:.1f}% (threshold: <80%)")
 
@@ -361,14 +329,12 @@ class MetricsAnalyzer:
             return self._analyze_metrics(metrics_data, query, context)
 
         # Prepare variables for the template
-        anomalies_str = (
-            "\n".join(anomalies_text) if anomalies_text else "No anomalies detected"
-        )
+        anomalies_str = "\n".join(anomalies_text) if anomalies_text else "No anomalies detected"
         vars = {
             "query": query,
             "service_name": service_name,
             "time_range": time_range,
-            "error_rate": f"{error_rate*100:.1f}%",
+            "error_rate": f"{error_rate * 100:.1f}%",
             "request_rate": f"{request_rate:.1f}",
             "latency_p95": f"{latency_p95:.0f}",
             "cpu_usage": f"{cpu_usage:.1f}",
@@ -416,14 +382,10 @@ class MetricsAnalyzer:
                         "confidence": 0.95 if parsed.get("anomalies") else 0.8,
                     }
                 except Exception:
-                    logger.warning(
-                        "Failed to parse JSON from LLM response, falling back to local analysis"
-                    )
+                    logger.warning("Failed to parse JSON from LLM response, falling back to local analysis")
 
             # If metrics_data is empty and user asked for last 5 minutes, return structured fallback
-            if not metrics_data and (
-                "5m" in time_range or "5" in time_range or "5 minutes" in prompt.lower()
-            ):
+            if not metrics_data and ("5m" in time_range or "5" in time_range or "5 minutes" in prompt.lower()):
                 return {
                     "summary": f"No metrics available for the last {time_range}.",
                     "data": {
@@ -457,9 +419,7 @@ class MetricsAnalyzer:
         base_url = "http://grafana:3000/explore"
         return [f"{base_url}?query={promql}&range={time_range}"]
 
-    async def _build_promql_queries_with_llm(
-        self, query: str, context: dict[str, Any]
-    ) -> list[str]:
+    async def _build_promql_queries_with_llm(self, query: str, context: dict[str, Any]) -> list[str]:
         """
         Use LLM to build optimized PromQL queries from prompt template
 
@@ -471,11 +431,7 @@ class MetricsAnalyzer:
             List of PromQL query strings
         """
         services = context.get("services", [])
-        services_context = (
-            f"Available services: {', '.join(services)}"
-            if services
-            else "No specific services mentioned"
-        )
+        services_context = f"Available services: {', '.join(services)}" if services else "No specific services mentioned"
 
         # Load prompt template from markdown file
         prompt_template = load_prompt("build_promql.md")
@@ -485,9 +441,7 @@ class MetricsAnalyzer:
 
         # Replace variables in template
         try:
-            prompt = prompt_template.format(
-                query=query, services_context=services_context
-            )
+            prompt = prompt_template.format(query=query, services_context=services_context)
         except KeyError as e:
             logger.error(f"Missing variable in build_promql.md template: {e}")
             return self._build_promql_queries(query, context)

--- a/agent-orchestrator/agent_orchestrator/main.py
+++ b/agent-orchestrator/agent_orchestrator/main.py
@@ -30,15 +30,9 @@ async def lifespan(app: FastAPI):
     global orchestrator
     # Startup
     logger.info("Orchestrator Agent starting up...")
-    logger.info(
-        f"Logs Agent URL: {os.getenv('AGENT_LOGS_URL', 'http://agent-logs:8002')}"
-    )
-    logger.info(
-        f"Metrics Agent URL: {os.getenv('AGENT_METRICS_URL', 'http://agent-metrics:8003')}"
-    )
-    logger.info(
-        f"Traces Agent URL: {os.getenv('AGENT_TRACES_URL', 'http://agent-traces:8004')}"
-    )
+    logger.info(f"Logs Agent URL: {os.getenv('AGENT_LOGS_URL', 'http://agent-logs:8002')}")
+    logger.info(f"Metrics Agent URL: {os.getenv('AGENT_METRICS_URL', 'http://agent-metrics:8003')}")
+    logger.info(f"Traces Agent URL: {os.getenv('AGENT_TRACES_URL', 'http://agent-traces:8004')}")
     logger.info(
         "Translation Agent URL: %s",
         os.getenv("AGENT_TRANSLATION_URL", "http://agent-traduction:8002"),
@@ -64,9 +58,7 @@ class AnalyzeRequest(BaseModel):
     query: str
     time_range: str = "1h"
     model: str | None = None
-    model_params: dict | None = (
-        None  # Optional LLM parameters (temperature, top_k, max_tokens)
-    )
+    model_params: dict | None = None  # Optional LLM parameters (temperature, top_k, max_tokens)
 
 
 class HealthResponse(BaseModel):

--- a/agent-orchestrator/agent_orchestrator/orchestrator.py
+++ b/agent-orchestrator/agent_orchestrator/orchestrator.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import os
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -41,24 +42,16 @@ class Orchestrator:
     def __init__(self):
         """Initialize orchestrator with agent endpoints"""
         self.logs_agent_url = os.getenv("AGENT_LOGS_URL", "http://agent-logs:8002")
-        self.metrics_agent_url = os.getenv(
-            "AGENT_METRICS_URL", "http://agent-metrics:8003"
-        )
-        self.traces_agent_url = os.getenv(
-            "AGENT_TRACES_URL", "http://agent-traces:8004"
-        )
-        self.translation_agent_url = os.getenv(
-            "AGENT_TRANSLATION_URL", "http://agent-traduction:8002"
-        )
+        self.metrics_agent_url = os.getenv("AGENT_METRICS_URL", "http://agent-metrics:8003")
+        self.traces_agent_url = os.getenv("AGENT_TRACES_URL", "http://agent-traces:8004")
+        self.translation_agent_url = os.getenv("AGENT_TRANSLATION_URL", "http://agent-traduction:8002")
 
         # Use configured timeout (600s by default to allow model loading)
         self.agent_call_timeout = int(os.getenv("AGENT_CALL_TIMEOUT", "600"))
         self.client = httpx.AsyncClient(timeout=self.agent_call_timeout)
 
         # Initialize LLM
-        self.llm_ephemeral = (
-            os.getenv("LLM_EPHEMERAL_PER_CALL", "false").lower() == "true"
-        )
+        self.llm_ephemeral = os.getenv("LLM_EPHEMERAL_PER_CALL", "false").lower() == "true"
         try:
             self.llm = None if self.llm_ephemeral else get_llm()
             if self.llm:
@@ -96,27 +89,16 @@ class Orchestrator:
         Returns:
             Analysis result with validation
         """
-        logger.info(
-            f"Analyzing query: {query} (model: {model}, params: {model_params})"
-        )
-        from datetime import datetime
+        logger.info(f"Analyzing query: {query} (model: {model}, params: {model_params})")
 
         # Step 1: Detect language and translate
-        language_info = await self._detect_and_translate(
-            query, model=model, model_params=model_params
-        )
+        language_info = await self._detect_and_translate(query, model=model, model_params=model_params)
         translated_query = language_info["translated_query"]
-        logger.info(
-            f"Language: {language_info['language']}, Translated: {translated_query}"
-        )
+        logger.info(f"Language: {language_info['language']}, Translated: {translated_query}")
 
-        intent = await self._classify_intent(
-            translated_query, model=model, model_params=model_params
-        )
+        intent = await self._classify_intent(translated_query, model=model, model_params=model_params)
         if intent == "chat":
-            chat_response = await self._generate_chat_response(
-                translated_query, model=model, model_params=model_params
-            )
+            chat_response = await self._generate_chat_response(translated_query, model=model, model_params=model_params)
             return {
                 "query": query,
                 "translated_query": translated_query,
@@ -146,9 +128,7 @@ class Orchestrator:
         agent_responses = await self._call_agents(routing["agents"], agent_request)
 
         # Step 4: Validate responses
-        validation = await self._validate_responses(
-            translated_query, agent_responses, model=model
-        )
+        validation = await self._validate_responses(translated_query, agent_responses, model=model)
 
         # Build final response
         summary_parts = []
@@ -157,15 +137,11 @@ class Orchestrator:
         for agent_name, response in agent_responses.items():
             if response and not isinstance(response.get("error"), str):
                 if "analysis" in response:
-                    summary_parts.append(
-                        f"**{agent_name.upper()}**: {response['analysis']}"
-                    )
+                    summary_parts.append(f"**{agent_name.upper()}**: {response['analysis']}")
                 if "recommendations" in response:
                     recommendations.extend(response["recommendations"])
 
-        summary = (
-            "\n\n".join(summary_parts) if summary_parts else "No analysis available"
-        )
+        summary = "\n\n".join(summary_parts) if summary_parts else "No analysis available"
 
         return {
             "query": query,
@@ -179,9 +155,7 @@ class Orchestrator:
             "timestamp": datetime.now(),
         }
 
-    async def _detect_and_translate(
-        self, query: str, model: str | None = None, model_params: dict | None = None
-    ) -> dict[str, Any]:
+    async def _detect_and_translate(self, query: str, model: str | None = None, model_params: dict | None = None) -> dict[str, Any]:
         """
         Functionality 1: Detect language and translate to English
 
@@ -228,9 +202,7 @@ class Orchestrator:
 
         return {"language": language, "translated_query": translated_query}
 
-    async def _route_to_agents(
-        self, query: str, model: str | None = None, model_params: dict | None = None
-    ) -> dict[str, Any]:
+    async def _route_to_agents(self, query: str, model: str | None = None, model_params: dict | None = None) -> dict[str, Any]:
         """
         Functionality 2: Decide which agents to call based on query
 
@@ -249,11 +221,7 @@ class Orchestrator:
         try:
             # Always use provided model if specified, otherwise fall back to default
             if model:
-                llm_client = (
-                    get_llm(model=model, **model_params)
-                    if model_params
-                    else get_llm(model=model)
-                )
+                llm_client = get_llm(model=model, **model_params) if model_params else get_llm(model=model)
             elif self.llm_ephemeral:
                 llm_client = get_llm(**model_params) if model_params else get_llm()
             else:
@@ -269,9 +237,7 @@ class Orchestrator:
                 return self._keyword_based_routing(query)
 
             route_prompt = route_prompt.format(query=query)
-            response_text = await self._invoke_llm_prompt(
-                route_prompt, model=model, model_params=model_params
-            )
+            response_text = await self._invoke_llm_prompt(route_prompt, model=model, model_params=model_params)
             if not response_text:
                 return self._keyword_based_routing(query)
 
@@ -360,9 +326,7 @@ class Orchestrator:
             payload["options"] = options
 
         logger.debug(f"Ollama payload: {payload}")
-        response = await self.client.post(
-            url, json=payload, timeout=self.agent_call_timeout
-        )
+        response = await self.client.post(url, json=payload, timeout=self.agent_call_timeout)
         response.raise_for_status()
         data = response.json()
         text = data.get("response", "") if isinstance(data, dict) else ""
@@ -383,16 +347,11 @@ class Orchestrator:
         agents = []
 
         # Check for logs keywords
-        if any(
-            word in query_lower for word in ["log", "error", "exception", "message"]
-        ):
+        if any(word in query_lower for word in ["log", "error", "exception", "message"]):
             agents.append("logs")
 
         # Check for metrics keywords
-        if any(
-            word in query_lower
-            for word in ["cpu", "memory", "latency", "rate", "throughput"]
-        ):
+        if any(word in query_lower for word in ["cpu", "memory", "latency", "rate", "throughput"]):
             agents.append("metrics")
 
         # Check for traces keywords
@@ -487,9 +446,7 @@ class Orchestrator:
         logger.info(f"Chat response generated: {response_text[:100]}...")
         return response_text
 
-    async def _call_agents(
-        self, agents: list[str], request: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def _call_agents(self, agents: list[str], request: dict[str, Any]) -> dict[str, Any]:
         """
         Call selected agents in parallel
 
@@ -523,17 +480,11 @@ class Orchestrator:
         result = {}
         for i, agent in enumerate([a for a in agents if a in agent_urls]):
             response = responses[i] if i < len(responses) else None
-            result[agent] = (
-                response
-                if not isinstance(response, Exception)
-                else {"error": str(response)}
-            )
+            result[agent] = response if not isinstance(response, Exception) else {"error": str(response)}
 
         return result
 
-    async def _query_agent(
-        self, agent_url: str, request: dict[str, Any]
-    ) -> dict[str, Any]:
+    async def _query_agent(self, agent_url: str, request: dict[str, Any]) -> dict[str, Any]:
         """
         Query a single agent
 
@@ -584,11 +535,7 @@ class Orchestrator:
         try:
             # Always use provided model if specified, otherwise fall back to default
             if model:
-                llm_client = (
-                    get_llm(model=model, **model_params)
-                    if model_params
-                    else get_llm(model=model)
-                )
+                llm_client = get_llm(model=model, **model_params) if model_params else get_llm(model=model)
             elif self.llm_ephemeral:
                 llm_client = get_llm(**model_params) if model_params else get_llm()
             else:
@@ -622,12 +569,8 @@ class Orchestrator:
                     "reason": "Validation prompt not found",
                 }
 
-            validate_prompt = validate_prompt.format(
-                query=query, response=combined_response
-            )
-            response_text = await self._invoke_llm_prompt(
-                validate_prompt, model=model, model_params=model_params
-            )
+            validate_prompt = validate_prompt.format(query=query, response=combined_response)
+            response_text = await self._invoke_llm_prompt(validate_prompt, model=model, model_params=model_params)
             if not response_text:
                 return {
                     "validated": False,

--- a/agent-orchestrator/tests/test_benchmark_models.py
+++ b/agent-orchestrator/tests/test_benchmark_models.py
@@ -51,9 +51,7 @@ def load_model_configs():
 
         return model_configs
     except Exception as e:
-        print(
-            f"{Colors.YELLOW}⚠️  Could not load model configs from config/ai/model-params.yml: {e}{Colors.END}"
-        )
+        print(f"{Colors.YELLOW}⚠️  Could not load model configs from config/ai/model-params.yml: {e}{Colors.END}")
         return {}
 
 

--- a/agent-orchestrator/tests/test_orchestrator_core.py
+++ b/agent-orchestrator/tests/test_orchestrator_core.py
@@ -29,9 +29,7 @@ class TestAgentRouting:
     async def test_route_to_logs_agent(self, orchestrator):
         """Test routing to logs agent for error queries"""
         with patch.object(orchestrator, "llm") as mock_llm:
-            mock_llm.invoke.return_value = Mock(
-                content='{"agents": ["logs"], "reason": "Error query"}'
-            )
+            mock_llm.invoke.return_value = Mock(content='{"agents": ["logs"], "reason": "Error query"}')
 
             result = await orchestrator._route_to_agents("Show me recent errors")
 
@@ -42,9 +40,7 @@ class TestAgentRouting:
     async def test_route_to_metrics_agent(self, orchestrator):
         """Test routing to metrics agent for performance queries"""
         with patch.object(orchestrator, "llm") as mock_llm:
-            mock_llm.invoke.return_value = Mock(
-                content='{"agents": ["metrics"], "reason": "CPU query"}'
-            )
+            mock_llm.invoke.return_value = Mock(content='{"agents": ["metrics"], "reason": "CPU query"}')
 
             result = await orchestrator._route_to_agents("What is the CPU usage?")
 
@@ -54,9 +50,7 @@ class TestAgentRouting:
     async def test_route_to_traces_agent(self, orchestrator):
         """Test routing to traces agent for slow request queries"""
         with patch.object(orchestrator, "llm") as mock_llm:
-            mock_llm.invoke.return_value = Mock(
-                content='{"agents": ["traces"], "reason": "Slow query"}'
-            )
+            mock_llm.invoke.return_value = Mock(content='{"agents": ["traces"], "reason": "Slow query"}')
 
             result = await orchestrator._route_to_agents("Which services are slow?")
 
@@ -66,9 +60,7 @@ class TestAgentRouting:
     async def test_route_to_multiple_agents(self, orchestrator):
         """Test routing to multiple agents for complex queries"""
         with patch.object(orchestrator, "llm") as mock_llm:
-            mock_llm.invoke.return_value = Mock(
-                content='{"agents": ["logs", "metrics"], "reason": "Complex query"}'
-            )
+            mock_llm.invoke.return_value = Mock(content='{"agents": ["logs", "metrics"], "reason": "Complex query"}')
 
             result = await orchestrator._route_to_agents("Show errors and CPU usage")
 
@@ -132,17 +124,11 @@ class TestResponseValidation:
     async def test_validate_valid_response(self, orchestrator):
         """Test validation of a good response"""
         with patch.object(orchestrator, "llm") as mock_llm:
-            mock_llm.invoke.return_value = Mock(
-                content='{"valid": true, "issues": [], "suggestion": "Good response"}'
-            )
+            mock_llm.invoke.return_value = Mock(content='{"valid": true, "issues": [], "suggestion": "Good response"}')
 
-            agent_responses = {
-                "logs": {"analysis": "Found 5 errors in the customer service"}
-            }
+            agent_responses = {"logs": {"analysis": "Found 5 errors in the customer service"}}
 
-            result = await orchestrator._validate_responses(
-                "Show me errors", agent_responses
-            )
+            result = await orchestrator._validate_responses("Show me errors", agent_responses)
 
             assert result["validated"]
             assert result["issues"] == []
@@ -151,15 +137,11 @@ class TestResponseValidation:
     async def test_validate_invalid_response(self, orchestrator):
         """Test validation of an incomplete response"""
         with patch.object(orchestrator, "llm") as mock_llm:
-            mock_llm.invoke.return_value = Mock(
-                content='{"valid": false, "issues": ["Missing concrete data"], "suggestion": "Add specific examples"}'
-            )
+            mock_llm.invoke.return_value = Mock(content='{"valid": false, "issues": ["Missing concrete data"], "suggestion": "Add specific examples"}')
 
             agent_responses = {"logs": {"analysis": "There might be some issues"}}
 
-            result = await orchestrator._validate_responses(
-                "Show me errors", agent_responses
-            )
+            result = await orchestrator._validate_responses("Show me errors", agent_responses)
 
             assert not result["validated"]
             assert len(result["issues"]) > 0
@@ -213,12 +195,8 @@ class TestEndToEndFlow:
         # Mock LLM responses for routing and validation
         with patch.object(orchestrator, "llm") as mock_llm:
             mock_llm.invoke.side_effect = [
-                Mock(
-                    content='{"agents": ["logs"], "reason": "Error query"}'
-                ),  # Routing
-                Mock(
-                    content='{"valid": true, "issues": [], "suggestion": "Good"}'
-                ),  # Validation
+                Mock(content='{"agents": ["logs"], "reason": "Error query"}'),  # Routing
+                Mock(content='{"valid": true, "issues": [], "suggestion": "Good"}'),  # Validation
             ]
 
             def build_response(payload: dict):
@@ -269,12 +247,8 @@ class TestEndToEndFlow:
         """Test complete flow with English query"""
         with patch.object(orchestrator, "llm") as mock_llm:
             mock_llm.invoke.side_effect = [
-                Mock(
-                    content='{"agents": ["metrics"], "reason": "CPU query"}'
-                ),  # Routing
-                Mock(
-                    content='{"valid": true, "issues": [], "suggestion": "Good"}'
-                ),  # Validation
+                Mock(content='{"agents": ["metrics"], "reason": "CPU query"}'),  # Routing
+                Mock(content='{"valid": true, "issues": [], "suggestion": "Good"}'),  # Validation
             ]
 
             def build_response(payload: dict):
@@ -322,12 +296,8 @@ class TestEndToEndFlow:
         """Test flow with multiple agents"""
         with patch.object(orchestrator, "llm") as mock_llm:
             mock_llm.invoke.side_effect = [
-                Mock(
-                    content='{"agents": ["logs", "metrics"], "reason": "Complex"}'
-                ),  # Routing
-                Mock(
-                    content='{"valid": true, "issues": [], "suggestion": "Good"}'
-                ),  # Validation
+                Mock(content='{"agents": ["logs", "metrics"], "reason": "Complex"}'),  # Routing
+                Mock(content='{"valid": true, "issues": [], "suggestion": "Good"}'),  # Validation
             ]
 
             def build_response(payload: dict):

--- a/agent-orchestrator/tests/test_orchestrator_integration.py
+++ b/agent-orchestrator/tests/test_orchestrator_integration.py
@@ -120,9 +120,7 @@ async def check_orchestrator_available():
             response = await client.get(f"{BASE_URL}/health")
             if response.status_code != 200:
                 print(f"Orchestrator returned status {response.status_code}")
-                pytest.skip(
-                    f"Orchestrator not healthy at {BASE_URL} (status: {response.status_code})"
-                )
+                pytest.skip(f"Orchestrator not healthy at {BASE_URL} (status: {response.status_code})")
             print("Orchestrator is available.")
     except Exception as e:
         print(f"Failed to connect to orchestrator: {e}")
@@ -197,17 +195,11 @@ async def run_agent_routing(
             print(f"  Reason: {Colors.YELLOW}{reason}{Colors.END}")
 
             # Verify that at least one expected agent was called
-            has_expected = any(
-                agent in agents_called for agent in test_case["expected_agents"]
-            )
+            has_expected = any(agent in agents_called for agent in test_case["expected_agents"])
             if strict:
-                assert (
-                    has_expected
-                ), f"Expected one of {test_case['expected_agents']}, got {agents_called}"
+                assert has_expected, f"Expected one of {test_case['expected_agents']}, got {agents_called}"
             elif not has_expected:
-                print(
-                    f"  {Colors.YELLOW}⚠️  Expected one of {test_case['expected_agents']}, got {agents_called}{Colors.END}"
-                )
+                print(f"  {Colors.YELLOW}⚠️  Expected one of {test_case['expected_agents']}, got {agents_called}{Colors.END}")
 
             print(f"  {Colors.GREEN}✓ Test {i} passed{Colors.END}\n")
             await asyncio.sleep(1)
@@ -263,9 +255,7 @@ async def run_response_validation(
             data = response.json()
             validation = data.get("validation", {})
 
-            print(
-                f"  Validation present: {Colors.YELLOW}{'validation' in data}{Colors.END}"
-            )
+            print(f"  Validation present: {Colors.YELLOW}{'validation' in data}{Colors.END}")
 
             if validation:
                 validated = validation.get("validated", False)
@@ -278,9 +268,7 @@ async def run_response_validation(
 
                 # Validation should have been attempted
                 if strict:
-                    assert (
-                        "validated" in validation or "reason" in validation
-                    ), "Validation result should be present"
+                    assert "validated" in validation or "reason" in validation, "Validation result should be present"
 
             print(f"  {Colors.GREEN}✓ Test {i} passed{Colors.END}\n")
             await asyncio.sleep(1)
@@ -314,9 +302,7 @@ async def run_complete_workflow(
     await check_orchestrator_available()
 
     print(f"\n{Colors.BOLD}{'=' * 80}{Colors.END}")
-    print(
-        f"{Colors.BOLD}TEST 3: COMPLETE WORKFLOW (Routing → Validation) (Model: {model}){Colors.END}"
-    )
+    print(f"{Colors.BOLD}TEST 3: COMPLETE WORKFLOW (Routing → Validation) (Model: {model}){Colors.END}")
     print(f"{Colors.BOLD}{'=' * 80}{Colors.END}\n")
 
     query = "Show me recent errors for the customer service"
@@ -355,9 +341,7 @@ async def run_complete_workflow(
         for agent_name, agent_resp in agent_responses.items():
             if agent_resp and isinstance(agent_resp, dict):
                 if "error" in agent_resp:
-                    print(
-                        f"  {Colors.RED}❌ {agent_name}: {agent_resp['error']}{Colors.END}"
-                    )
+                    print(f"  {Colors.RED}❌ {agent_name}: {agent_resp['error']}{Colors.END}")
                 else:
                     analysis = agent_resp.get("analysis", "")[:100]
                     print(f"  {Colors.GREEN}✓ {agent_name}: {analysis}...{Colors.END}")
@@ -413,9 +397,7 @@ async def main():
     start_time = datetime.now()
 
     print(f"\n{Colors.BOLD}╔{'=' * 78}╗{Colors.END}")
-    print(
-        f"{Colors.BOLD}║{' ' * 15}INTEGRATION TESTS - SIMPLIFIED ORCHESTRATOR{' ' * 20}║{Colors.END}"
-    )
+    print(f"{Colors.BOLD}║{' ' * 15}INTEGRATION TESTS - SIMPLIFIED ORCHESTRATOR{' ' * 20}║{Colors.END}")
     print(f"{Colors.BOLD}╚{'=' * 78}╝{Colors.END}")
 
     try:
@@ -437,9 +419,7 @@ async def main():
         print(f"{Colors.BOLD}{'=' * 80}{Colors.END}\n")
 
         print(f"{Colors.BOLD}📊 VERIFIED FUNCTIONALITIES:{Colors.END}")
-        print(
-            f"   {Colors.GREEN}✓ Intelligent routing to correct agents (logs/metrics/traces){Colors.END}"
-        )
+        print(f"   {Colors.GREEN}✓ Intelligent routing to correct agents (logs/metrics/traces){Colors.END}")
         print(f"   {Colors.GREEN}✓ AI-powered response validation{Colors.END}")
         print(f"   {Colors.GREEN}✓ Complete end-to-end workflow{Colors.END}\n")
 

--- a/agent-traces/agent_traces/main.py
+++ b/agent-traces/agent_traces/main.py
@@ -30,9 +30,7 @@ async def lifespan(app: FastAPI):
     global analyzer
     # Startup
     logger.info("Traces Agent starting up...")
-    logger.info(
-        f"MCP Grafana URL: {os.getenv('MCP_GRAFANA_URL', 'http://grafana-mcp:8000')}"
-    )
+    logger.info(f"MCP Grafana URL: {os.getenv('MCP_GRAFANA_URL', 'http://grafana-mcp:8000')}")
     analyzer = TracesAnalyzer()
     yield
     # Shutdown

--- a/agent-traces/agent_traces/traces_analyzer.py
+++ b/agent-traces/agent_traces/traces_analyzer.py
@@ -87,9 +87,7 @@ class TracesAnalyzer:
 
         # Analyze trace data with LLM if available
         if self.llm and traces_data.get("traces"):
-            analysis = await self._analyze_traces_with_llm(
-                traces_data, query, context, time_range
-            )
+            analysis = await self._analyze_traces_with_llm(traces_data, query, context, time_range)
         else:
             analysis = self._analyze_traces(traces_data, query, context)
 
@@ -152,9 +150,7 @@ class TracesAnalyzer:
         logger.info(f"Querying Tempo with: {traceql}")
 
         # Query via MCP client
-        result = await self.mcp_client.query_traces(
-            query=traceql, time_range=time_range, limit=50
-        )
+        result = await self.mcp_client.query_traces(query=traceql, time_range=time_range, limit=50)
 
         # Return in expected format
         if "error" in result:
@@ -217,11 +213,7 @@ class TracesAnalyzer:
         # Calculate average durations for bottlenecks
         bottleneck_list = []
         for key, data in bottlenecks.items():
-            avg_dur = (
-                sum(data["durations"]) / len(data["durations"])
-                if data["durations"]
-                else 0
-            )
+            avg_dur = sum(data["durations"]) / len(data["durations"]) if data["durations"] else 0
             if avg_dur > 100:  # Only include slow operations
                 bottleneck_list.append(
                     {
@@ -236,14 +228,10 @@ class TracesAnalyzer:
 
         # Build summary
         time_range_checked = context.get("time_range", "1h")
-        summary_parts = [
-            f"Analyzed {total_count} traces over the last {time_range_checked}."
-        ]
+        summary_parts = [f"Analyzed {total_count} traces over the last {time_range_checked}."]
 
         if failed_count > 0 and total_count > 0:
-            summary_parts.append(
-                f"Found {failed_count} failed traces ({failed_count/total_count*100:.1f}% failure rate)."
-            )
+            summary_parts.append(f"Found {failed_count} failed traces ({failed_count / total_count * 100:.1f}% failure rate).")
 
         summary_parts.append(f"Average trace duration: {int(avg_duration)}ms.")
 
@@ -252,14 +240,9 @@ class TracesAnalyzer:
 
         if bottleneck_list:
             top_bottleneck = bottleneck_list[0]
-            summary_parts.append(
-                f"Primary bottleneck: {top_bottleneck['service']}.{top_bottleneck['operation']} "
-                f"({top_bottleneck['avg_duration_ms']}ms average)."
-            )
+            summary_parts.append(f"Primary bottleneck: {top_bottleneck['service']}.{top_bottleneck['operation']} ({top_bottleneck['avg_duration_ms']}ms average).")
 
-        summary_parts.append(
-            f"Service dependency chain: {' → '.join(sorted(all_services))}."
-        )
+        summary_parts.append(f"Service dependency chain: {' → '.join(sorted(all_services))}.")
 
         return {
             "summary": " ".join(summary_parts),
@@ -315,11 +298,7 @@ class TracesAnalyzer:
         # Simple statistics (no complex calculations!)
         slow_count = sum(1 for t in traces if t.get("duration_ms", 0) > 500)
         failed_count = sum(1 for t in traces if t.get("error", False))
-        avg_duration = (
-            sum(t.get("duration_ms", 0) for t in traces) / total_traces
-            if total_traces > 0
-            else 0
-        )
+        avg_duration = sum(t.get("duration_ms", 0) for t in traces) / total_traces if total_traces > 0 else 0
 
         # Extract unique services (simple set operation)
         services = set()
@@ -334,9 +313,7 @@ class TracesAnalyzer:
             duration = trace.get("duration_ms", 0)
             spans = len(trace.get("spans", []))
             error = trace.get("error", False)
-            trace_samples_text.append(
-                f"- {trace_id}: {duration}ms, {spans} spans, error={error}"
-            )
+            trace_samples_text.append(f"- {trace_id}: {duration}ms, {spans} spans, error={error}")
 
         # Load prompt template from markdown file
         prompt_template = load_prompt("analyze_traces.md")
@@ -345,9 +322,7 @@ class TracesAnalyzer:
             return self._analyze_traces(traces_data, query, context)
 
         # Prepare variables for the template
-        trace_samples_str = (
-            "\n".join(trace_samples_text) if trace_samples_text else "No traces found"
-        )
+        trace_samples_str = "\n".join(trace_samples_text) if trace_samples_text else "No traces found"
         vars = {
             "query": query,
             "time_range": time_range,
@@ -394,19 +369,13 @@ class TracesAnalyzer:
                     return {
                         "summary": parsed.get("summary", ""),
                         "data": parsed,
-                        "confidence": (
-                            0.95 if parsed.get("total_traces", 0) > 0 else 0.5
-                        ),
+                        "confidence": (0.95 if parsed.get("total_traces", 0) > 0 else 0.5),
                     }
                 except Exception:
-                    logger.warning(
-                        "Failed to parse JSON from LLM response, falling back"
-                    )
+                    logger.warning("Failed to parse JSON from LLM response, falling back")
 
             # If no traces and user asked for last 5 minutes, return structured fallback
-            if total_traces == 0 and (
-                "5m" in time_range or "5" in time_range or "5 minutes" in prompt.lower()
-            ):
+            if total_traces == 0 and ("5m" in time_range or "5" in time_range or "5 minutes" in prompt.lower()):
                 return {
                     "summary": f"Found 0 traces in the last {time_range}.",
                     "data": {
@@ -429,9 +398,7 @@ class TracesAnalyzer:
             logger.warning(f"LLM analysis failed: {e}, using fallback")
             return self._analyze_traces(traces_data, query, context)
 
-    async def _build_traceql_query_with_llm(
-        self, query: str, context: dict[str, Any]
-    ) -> str:
+    async def _build_traceql_query_with_llm(self, query: str, context: dict[str, Any]) -> str:
         """
         Use LLM to build an optimized TraceQL query from prompt template
 
@@ -443,11 +410,7 @@ class TracesAnalyzer:
             TraceQL query string
         """
         services = context.get("services", [])
-        services_context = (
-            f"Available services: {', '.join(services)}"
-            if services
-            else "No specific services mentioned"
-        )
+        services_context = f"Available services: {', '.join(services)}" if services else "No specific services mentioned"
 
         # Load prompt template from markdown file
         prompt_template = load_prompt("build_traceql.md")
@@ -457,9 +420,7 @@ class TracesAnalyzer:
 
         # Replace variables in template
         try:
-            prompt = prompt_template.format(
-                query=query, services_context=services_context
-            )
+            prompt = prompt_template.format(query=query, services_context=services_context)
         except KeyError as e:
             logger.error(f"Missing variable in build_traceql.md template: {e}")
             return self._build_traceql_query(query, context)

--- a/agent-traduction/agent_traduction/translation_service.py
+++ b/agent-traduction/agent_traduction/translation_service.py
@@ -30,9 +30,7 @@ class TranslationService:
     """Handle language detection and translation using an LLM."""
 
     def __init__(self) -> None:
-        self.llm_ephemeral = (
-            os.getenv("LLM_EPHEMERAL_PER_CALL", "false").lower() == "true"
-        )
+        self.llm_ephemeral = os.getenv("LLM_EPHEMERAL_PER_CALL", "false").lower() == "true"
         try:
             self.llm = None if self.llm_ephemeral else get_llm()
             if self.llm:
@@ -70,9 +68,7 @@ class TranslationService:
         try:
             language = self._detect_language(query, model, model_params)
             if language == "non-english":
-                translated_query = self._translate_to_english(
-                    query, model, model_params
-                )
+                translated_query = self._translate_to_english(query, model, model_params)
             else:
                 translated_query = query
 
@@ -102,9 +98,7 @@ class TranslationService:
         if not prompt:
             return "unknown"
 
-        response_text = self._invoke_llm_prompt(
-            prompt.format(query=query), model, model_params
-        )
+        response_text = self._invoke_llm_prompt(prompt.format(query=query), model, model_params)
         if not response_text:
             return "unknown"
 
@@ -127,9 +121,7 @@ class TranslationService:
         if not prompt:
             return query
 
-        response_text = self._invoke_llm_prompt(
-            prompt.format(query=query), model, model_params
-        )
+        response_text = self._invoke_llm_prompt(prompt.format(query=query), model, model_params)
         if not response_text:
             return query
 
@@ -145,9 +137,7 @@ class TranslationService:
             return get_llm(**params)
         return self.llm
 
-    def _invoke_llm_prompt(
-        self, prompt: str, model: str | None, model_params: dict | None
-    ) -> str | None:
+    def _invoke_llm_prompt(self, prompt: str, model: str | None, model_params: dict | None) -> str | None:
         llm_client = self._get_llm(model, model_params)
         if llm_client:
             try:
@@ -164,9 +154,7 @@ class TranslationService:
             logger.warning("Ollama fallback failed: %s", exc)
             return None
 
-    def _ollama_generate(
-        self, prompt: str, model: str | None, model_params: dict | None
-    ) -> str | None:
+    def _ollama_generate(self, prompt: str, model: str | None, model_params: dict | None) -> str | None:
         base_url = os.getenv("LLM_BASE_URL", "http://localhost:11434/v1")
         if base_url.endswith("/v1"):
             base_url = base_url[:-3]

--- a/agent-traduction/tests/test_translation_service.py
+++ b/agent-traduction/tests/test_translation_service.py
@@ -24,9 +24,7 @@ def test_translate_english_query_returns_same_text():
 
 def test_translate_non_english_query_translates():
     with patch("agent_traduction.translation_service.get_llm") as mock_get_llm:
-        mock_get_llm.return_value = _mock_llm_with_side_effect(
-            ["NOT_ENGLISH", "Show me recent errors"]
-        )
+        mock_get_llm.return_value = _mock_llm_with_side_effect(["NOT_ENGLISH", "Show me recent errors"])
 
         service = TranslationService()
         result = service.translate("Montre-moi les erreurs récentes")

--- a/agent-ui/agent_ui/main.py
+++ b/agent-ui/agent_ui/main.py
@@ -4,7 +4,6 @@ Main FastAPI application for the Agents UI - Professional dark theme
 
 import logging
 import os
-from typing import List
 
 import httpx
 from fastapi import FastAPI, Form, Request
@@ -16,20 +15,23 @@ from pydantic import BaseModel
 # Setup logging
 logger = logging.getLogger("agent_ui")
 
+
 # Models
 class QA(BaseModel):
     """A question and answer pair."""
+
     question: str
     answer: str = ""
+
 
 class ChatState:
     """The app state."""
 
     def __init__(self):
-        self.chats: List[QA] = []
+        self.chats: list[QA] = []
         self.processing: bool = False
 
-    def get_messages(self) -> List[dict]:
+    def get_messages(self) -> list[dict]:
         """Get messages in the format expected by the UI.
 
         Returns:
@@ -50,6 +52,7 @@ class ChatState:
         """
         return self.processing
 
+
 # Global state
 chat_state = ChatState()
 
@@ -64,25 +67,16 @@ templates = Jinja2Templates(directory="agent_ui/templates")
 if os.path.exists("agent_ui/static"):
     app.mount("/static", StaticFiles(directory="agent_ui/static"), name="static")
 
+
 @app.get("/", response_class=HTMLResponse)
 async def read_root(request: Request):
     """Render the main chat interface."""
     logger.info("Rendering main page")
-    return templates.TemplateResponse(
-        "index.html",
-        {
-            "request": request,
-            "chats": chat_state.chats,
-            "processing": chat_state.processing,
-            "root_path": root_path
-        }
-    )
+    return templates.TemplateResponse("index.html", {"request": request, "chats": chat_state.chats, "processing": chat_state.processing, "root_path": root_path})
+
 
 @app.post("/send_message")
-async def send_message(
-    request: Request,
-    question: str = Form(...)
-):
+async def send_message(request: Request, question: str = Form(...)):
     """Process a new message.
 
     Args:
@@ -102,16 +96,12 @@ async def send_message(
     logger.info("Processing question...")
 
     # Call orchestrator API
-    orchestrator_url = os.getenv(
-        "ORCHESTRATOR_URL", "http://agent-orchestrator:8001"
-    )
+    orchestrator_url = os.getenv("ORCHESTRATOR_URL", "http://agent-orchestrator:8001")
 
     # Detect time range in question (e.g., "last 5 minutes")
     time_range = "1h"
     q_lower = question.lower()
-    if "5" in q_lower and (
-        "minute" in q_lower or "minutes" in q_lower or "5m" in q_lower
-    ):
+    if "5" in q_lower and ("minute" in q_lower or "minutes" in q_lower or "5m" in q_lower):
         time_range = "5m"
 
     try:
@@ -149,12 +139,15 @@ async def send_message(
 
     return {"status": "success", "answer": answer}
 
+
 @app.get("/health")
 async def health_check():
     """Health check endpoint."""
     return {"status": "healthy", "service": "agent-ui"}
 
+
 if __name__ == "__main__":
     import uvicorn
+
     logger.info("Starting Agent UI server...")
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/benchmark/benchmark/agent_requests.py
+++ b/benchmark/benchmark/agent_requests.py
@@ -12,9 +12,7 @@ class BenchmarkResult(BaseModel):
     model: str
     agent: str
     latency_ms: float = Field(..., description="Request latency in milliseconds")
-    memory_delta_mb: float = Field(
-        default=0.0, description="Memory usage delta in MB"
-    )
+    memory_delta_mb: float = Field(default=0.0, description="Memory usage delta in MB")
     success: bool = Field(default=True, description="Whether request succeeded")
     error: str | None = Field(default=None, description="Error message if failed")
     timestamp: datetime = Field(default_factory=datetime.utcnow)
@@ -47,9 +45,7 @@ class OrchestratorRequest(BaseModel):
     query: str
     time_range: str = Field(default="1h")
     model: str | None = Field(default="mistral:7b", description="LLM model to use")
-    model_params: dict | None = Field(
-        default=None, description="Optional LLM parameters (temperature, top_k, max_tokens)"
-    )
+    model_params: dict | None = Field(default=None, description="Optional LLM parameters (temperature, top_k, max_tokens)")
 
 
 class LogsAnalysisRequest(BaseModel):

--- a/benchmark/benchmark/agents/logs.py
+++ b/benchmark/benchmark/agents/logs.py
@@ -54,10 +54,7 @@ class LogsBenchmark:
         Returns:
             List of benchmark results
         """
-        logger.info(
-            f"Benchmarking logs /analyze endpoint "
-            f"({num_requests} requests with {model})"
-        )
+        logger.info(f"Benchmarking logs /analyze endpoint ({num_requests} requests with {model})")
 
         results = []
 
@@ -86,19 +83,18 @@ class LogsBenchmark:
                     success=True,
                     metadata={"request_num": i + 1, "response_length": len(str(data))},
                 )
-                results.append({
-                    "request_num": i + 1,
-                    "latency_ms": latency_ms,
-                    "success": True,
-                    "request": request.model_dump(),
-                    "response": data,
-                    "response_preview": str(data)[:100],
-                })
-
-                logger.debug(
-                    f"Request {i + 1}/{num_requests}: "
-                    f"{latency_ms:.2f}ms"
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "latency_ms": latency_ms,
+                        "success": True,
+                        "request": request.model_dump(),
+                        "response": data,
+                        "response_preview": str(data)[:100],
+                    }
                 )
+
+                logger.debug(f"Request {i + 1}/{num_requests}: {latency_ms:.2f}ms")
 
             except Exception as e:
                 logger.error(f"Request {i + 1}/{num_requests} failed: {e}")
@@ -109,12 +105,14 @@ class LogsBenchmark:
                     success=False,
                     error=str(e),
                 )
-                results.append({
-                    "request_num": i + 1,
-                    "success": False,
-                    "error": str(e),
-                    "request": request.model_dump() if 'request' in locals() else None,
-                })
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "success": False,
+                        "error": str(e),
+                        "request": request.model_dump() if "request" in locals() else None,
+                    }
+                )
 
             if i < num_requests - 1:
                 await asyncio.sleep(0.1)

--- a/benchmark/benchmark/agents/metrics.py
+++ b/benchmark/benchmark/agents/metrics.py
@@ -55,10 +55,7 @@ class MetricsBenchmark:
         Returns:
             List of benchmark results
         """
-        logger.info(
-            f"Benchmarking metrics /analyze endpoint "
-            f"({num_requests} requests with {model})"
-        )
+        logger.info(f"Benchmarking metrics /analyze endpoint ({num_requests} requests with {model})")
 
         results = []
 
@@ -89,19 +86,18 @@ class MetricsBenchmark:
                     metadata={"request_num": i + 1, "response_length": len(str(data))},
                 )
 
-                results.append({
-                    "request_num": i + 1,
-                    "latency_ms": latency_ms,
-                    "success": True,
-                    "request": request.model_dump(),
-                    "response": data,
-                    "response_preview": str(data)[:100],
-                })
-
-                logger.debug(
-                    f"Request {i + 1}/{num_requests}: "
-                    f"{latency_ms:.2f}ms"
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "latency_ms": latency_ms,
+                        "success": True,
+                        "request": request.model_dump(),
+                        "response": data,
+                        "response_preview": str(data)[:100],
+                    }
                 )
+
+                logger.debug(f"Request {i + 1}/{num_requests}: {latency_ms:.2f}ms")
 
             except Exception as e:
                 logger.error(f"Request {i + 1}/{num_requests} failed: {e}")
@@ -112,12 +108,14 @@ class MetricsBenchmark:
                     success=False,
                     error=str(e),
                 )
-                results.append({
-                    "request_num": i + 1,
-                    "success": False,
-                    "error": str(e),
-                    "request": request.model_dump() if 'request' in locals() else None,
-                })
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "success": False,
+                        "error": str(e),
+                        "request": request.model_dump() if "request" in locals() else None,
+                    }
+                )
 
             if i < num_requests - 1:
                 await asyncio.sleep(0.1)

--- a/benchmark/benchmark/agents/orchestrator.py
+++ b/benchmark/benchmark/agents/orchestrator.py
@@ -57,10 +57,7 @@ class OrchestratorBenchmark:
         Returns:
             List of benchmark results
         """
-        logger.info(
-            f"Benchmarking orchestrator /analyze endpoint "
-            f"({num_requests} requests with {model})"
-        )
+        logger.info(f"Benchmarking orchestrator /analyze endpoint ({num_requests} requests with {model})")
 
         results = []
 
@@ -92,19 +89,18 @@ class OrchestratorBenchmark:
                     metadata={"request_num": i + 1, "response_length": len(str(data))},
                 )
 
-                results.append({
-                    "request_num": i + 1,
-                    "latency_ms": latency_ms,
-                    "success": True,
-                    "request": request.model_dump(),
-                    "response": data,
-                    "response_preview": str(data)[:100],
-                })
-
-                logger.debug(
-                    f"Request {i + 1}/{num_requests}: "
-                    f"{latency_ms:.2f}ms"
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "latency_ms": latency_ms,
+                        "success": True,
+                        "request": request.model_dump(),
+                        "response": data,
+                        "response_preview": str(data)[:100],
+                    }
                 )
+
+                logger.debug(f"Request {i + 1}/{num_requests}: {latency_ms:.2f}ms")
 
             except Exception as e:
                 logger.error(f"Request {i + 1}/{num_requests} failed: {e}")
@@ -115,12 +111,14 @@ class OrchestratorBenchmark:
                     success=False,
                     error=str(e),
                 )
-                results.append({
-                    "request_num": i + 1,
-                    "success": False,
-                    "error": str(e),
-                    "request": request.model_dump() if 'request' in locals() else None,
-                })
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "success": False,
+                        "error": str(e),
+                        "request": request.model_dump() if "request" in locals() else None,
+                    }
+                )
 
             if i < num_requests - 1:
                 await asyncio.sleep(0.1)  # Small delay between requests

--- a/benchmark/benchmark/agents/traces.py
+++ b/benchmark/benchmark/agents/traces.py
@@ -57,10 +57,7 @@ class TracesBenchmark:
         Returns:
             List of benchmark results
         """
-        logger.info(
-            f"Benchmarking traces /analyze endpoint "
-            f"({num_requests} requests with {model})"
-        )
+        logger.info(f"Benchmarking traces /analyze endpoint ({num_requests} requests with {model})")
 
         results = []
 
@@ -92,19 +89,18 @@ class TracesBenchmark:
                     metadata={"request_num": i + 1, "response_length": len(str(data))},
                 )
 
-                results.append({
-                    "request_num": i + 1,
-                    "latency_ms": latency_ms,
-                    "success": True,
-                    "request": request.model_dump(),
-                    "response": data,
-                    "response_preview": str(data)[:100],
-                })
-
-                logger.debug(
-                    f"Request {i + 1}/{num_requests}: "
-                    f"{latency_ms:.2f}ms"
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "latency_ms": latency_ms,
+                        "success": True,
+                        "request": request.model_dump(),
+                        "response": data,
+                        "response_preview": str(data)[:100],
+                    }
                 )
+
+                logger.debug(f"Request {i + 1}/{num_requests}: {latency_ms:.2f}ms")
 
             except Exception as e:
                 logger.error(f"Request {i + 1}/{num_requests} failed: {e}")
@@ -115,12 +111,14 @@ class TracesBenchmark:
                     success=False,
                     error=str(e),
                 )
-                results.append({
-                    "request_num": i + 1,
-                    "success": False,
-                    "error": str(e),
-                    "request": request.model_dump() if 'request' in locals() else None,
-                })
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "success": False,
+                        "error": str(e),
+                        "request": request.model_dump() if "request" in locals() else None,
+                    }
+                )
 
             if i < num_requests - 1:
                 await asyncio.sleep(0.1)

--- a/benchmark/benchmark/agents/translation.py
+++ b/benchmark/benchmark/agents/translation.py
@@ -53,10 +53,7 @@ class TranslationBenchmark:
         Returns:
             List of benchmark results
         """
-        logger.info(
-            f"Benchmarking translation /translate endpoint "
-            f"({num_requests} requests with {model})"
-        )
+        logger.info(f"Benchmarking translation /translate endpoint ({num_requests} requests with {model})")
 
         results = []
 
@@ -86,19 +83,18 @@ class TranslationBenchmark:
                     metadata={"request_num": i + 1, "response_length": len(str(data))},
                 )
 
-                results.append({
-                    "request_num": i + 1,
-                    "latency_ms": latency_ms,
-                    "success": True,
-                    "request": request.model_dump(),
-                    "response": data,
-                    "response_preview": str(data)[:100],
-                })
-
-                logger.debug(
-                    f"Request {i + 1}/{num_requests}: "
-                    f"{latency_ms:.2f}ms"
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "latency_ms": latency_ms,
+                        "success": True,
+                        "request": request.model_dump(),
+                        "response": data,
+                        "response_preview": str(data)[:100],
+                    }
                 )
+
+                logger.debug(f"Request {i + 1}/{num_requests}: {latency_ms:.2f}ms")
 
             except Exception as e:
                 logger.error(f"Request {i + 1}/{num_requests} failed: {e}")
@@ -109,12 +105,14 @@ class TranslationBenchmark:
                     success=False,
                     error=str(e),
                 )
-                results.append({
-                    "request_num": i + 1,
-                    "success": False,
-                    "error": str(e),
-                    "request": request.model_dump() if 'request' in locals() else None,
-                })
+                results.append(
+                    {
+                        "request_num": i + 1,
+                        "success": False,
+                        "error": str(e),
+                        "request": request.model_dump() if "request" in locals() else None,
+                    }
+                )
 
             if i < num_requests - 1:
                 await asyncio.sleep(0.1)

--- a/benchmark/benchmark/benchmarks/logs.py
+++ b/benchmark/benchmark/benchmarks/logs.py
@@ -72,7 +72,7 @@ async def benchmark_logs_agent() -> dict:
                 print_endpoint_header("Analyze endpoint", f"{len(queries)} tests × {benchmark.config.NUM_TEST_REQUESTS} runs = {total_expected} total")
                 for i, result in enumerate(results, 1):
                     if result.get("success", False):
-                        print_request_result(i, result['latency_ms'], True)
+                        print_request_result(i, result["latency_ms"], True)
                         # Show request (query only)
                         if result.get("request"):
                             query = extract_query(result["request"])
@@ -81,18 +81,16 @@ async def benchmark_logs_agent() -> dict:
                         # Show response
                         if result.get("response"):
                             print_response(result["response"])
-                            is_valid, validation_msg = validate_agent_response(
-                                "logs", result["response"]
-                            )
+                            is_valid, validation_msg = validate_agent_response("logs", result["response"])
                             print_validation(is_valid, validation_msg)
                             if is_valid:
                                 valid_tests += 1
                             else:
                                 validation_failed = True
-                        timings.append(result['latency_ms'])
+                        timings.append(result["latency_ms"])
                         all_results.append(result)
                     else:
-                        print_request_result(i, 0, False, result.get('error', 'Unknown'))
+                        print_request_result(i, 0, False, result.get("error", "Unknown"))
                         if result.get("request"):
                             query = extract_query(result["request"])
                             print_query(query)

--- a/benchmark/benchmark/benchmarks/metrics.py
+++ b/benchmark/benchmark/benchmarks/metrics.py
@@ -72,7 +72,7 @@ async def benchmark_metrics_agent() -> dict:
                 print_endpoint_header("Analyze endpoint", f"{len(queries)} tests × {benchmark.config.NUM_TEST_REQUESTS} runs = {total_expected} total")
                 for i, result in enumerate(results, 1):
                     if result.get("success", False):
-                        print_request_result(i, result['latency_ms'], True)
+                        print_request_result(i, result["latency_ms"], True)
                         # Show request (query only)
                         if result.get("request"):
                             query = extract_query(result["request"])
@@ -81,18 +81,16 @@ async def benchmark_metrics_agent() -> dict:
                         # Show response
                         if result.get("response"):
                             print_response(result["response"])
-                            is_valid, validation_msg = validate_agent_response(
-                                "metrics", result["response"]
-                            )
+                            is_valid, validation_msg = validate_agent_response("metrics", result["response"])
                             print_validation(is_valid, validation_msg)
                             if is_valid:
                                 valid_tests += 1
                             else:
                                 validation_failed = True
-                        timings.append(result['latency_ms'])
+                        timings.append(result["latency_ms"])
                         all_results.append(result)
                     else:
-                        print_request_result(i, 0, False, result.get('error', 'Unknown'))
+                        print_request_result(i, 0, False, result.get("error", "Unknown"))
                         if result.get("request"):
                             query = extract_query(result["request"])
                             print_query(query)

--- a/benchmark/benchmark/benchmarks/orchestrator.py
+++ b/benchmark/benchmark/benchmarks/orchestrator.py
@@ -86,7 +86,7 @@ async def benchmark_orchestrator() -> dict:
                 print_endpoint_header("Analyze endpoint", f"{len(queries)} tests × {benchmark.config.NUM_TEST_REQUESTS} iterations = {total_expected} total")
                 for i, result in enumerate(results, 1):
                     if result.get("success", False):
-                        print_request_result(i, result['latency_ms'], True)
+                        print_request_result(i, result["latency_ms"], True)
                         # Show request (query only)
                         if result.get("request"):
                             query = extract_query(result["request"])
@@ -95,32 +95,25 @@ async def benchmark_orchestrator() -> dict:
                         # Show response
                         if result.get("response"):
                             print_response(result["response"])
-                            is_valid, validation_msg = validate_orchestrator_response(
-                                result["response"]
-                            )
+                            is_valid, validation_msg = validate_orchestrator_response(result["response"])
                             print_validation(is_valid, validation_msg)
                             # Also check model
-                            model_valid, model_msg = validate_model_in_response(
-                                result["response"], model
-                            )
+                            model_valid, model_msg = validate_model_in_response(result["response"], model)
                             print_validation(model_valid, f"model: {model_msg}")
                             # Also validate routing
                             routing_valid = True
                             if is_valid and result.get("request"):
-                                routing_valid, routing_msg = validate_routing(
-                                    result["response"],
-                                    extract_query(result["request"])
-                                )
+                                routing_valid, routing_msg = validate_routing(result["response"], extract_query(result["request"]))
                                 print_validation(routing_valid, f"routing: {routing_msg}")
                             # Count as valid only if both structure and routing are valid
                             if is_valid and routing_valid:
                                 valid_tests += 1
                             else:
                                 validation_failed = True
-                        timings.append(result['latency_ms'])
+                        timings.append(result["latency_ms"])
                         all_results.append(result)
                     else:
-                        print_request_result(i, 0, False, result.get('error', 'Unknown'))
+                        print_request_result(i, 0, False, result.get("error", "Unknown"))
                         if result.get("request"):
                             query = extract_query(result["request"])
                             print_query(query)

--- a/benchmark/benchmark/benchmarks/traces.py
+++ b/benchmark/benchmark/benchmarks/traces.py
@@ -72,7 +72,7 @@ async def benchmark_traces_agent() -> dict:
                 print_endpoint_header("Analyze endpoint", f"{len(queries)} tests × {benchmark.config.NUM_TEST_REQUESTS} runs = {total_expected} total")
                 for i, result in enumerate(results, 1):
                     if result.get("success", False):
-                        print_request_result(i, result['latency_ms'], True)
+                        print_request_result(i, result["latency_ms"], True)
                         # Show request (query only)
                         if result.get("request"):
                             query = extract_query(result["request"])
@@ -81,18 +81,16 @@ async def benchmark_traces_agent() -> dict:
                         # Show response
                         if result.get("response"):
                             print_response(result["response"])
-                            is_valid, validation_msg = validate_agent_response(
-                                "traces", result["response"]
-                            )
+                            is_valid, validation_msg = validate_agent_response("traces", result["response"])
                             print_validation(is_valid, validation_msg)
                             if is_valid:
                                 valid_tests += 1
                             else:
                                 validation_failed = True
-                        timings.append(result['latency_ms'])
+                        timings.append(result["latency_ms"])
                         all_results.append(result)
                     else:
-                        print_request_result(i, 0, False, result.get('error', 'Unknown'))
+                        print_request_result(i, 0, False, result.get("error", "Unknown"))
                         if result.get("request"):
                             query = extract_query(result["request"])
                             print_query(query)

--- a/benchmark/benchmark/benchmarks/translation.py
+++ b/benchmark/benchmark/benchmarks/translation.py
@@ -72,7 +72,7 @@ async def benchmark_translation_agent() -> dict:
                 print_endpoint_header("Translate endpoint", f"{len(translation_inputs)} tests × {benchmark.config.NUM_TEST_REQUESTS} runs = {total_expected} total")
                 for i, result in enumerate(results, 1):
                     if result.get("success", False):
-                        print_request_result(i, result['latency_ms'], True)
+                        print_request_result(i, result["latency_ms"], True)
                         # Show request (input only)
                         if result.get("request"):
                             input_text = extract_query(result["request"])
@@ -81,18 +81,16 @@ async def benchmark_translation_agent() -> dict:
                         # Show response
                         if result.get("response"):
                             print_response(result["response"])
-                            is_valid, validation_msg = validate_agent_response(
-                                "translation", result["response"]
-                            )
+                            is_valid, validation_msg = validate_agent_response("translation", result["response"])
                             print_validation(is_valid, validation_msg)
                             if is_valid:
                                 valid_tests += 1
                             else:
                                 validation_failed = True
-                        timings.append(result['latency_ms'])
+                        timings.append(result["latency_ms"])
                         all_results.append(result)
                     else:
-                        print_request_result(i, 0, False, result.get('error', 'Unknown'))
+                        print_request_result(i, 0, False, result.get("error", "Unknown"))
                         if result.get("request"):
                             input_text = extract_query(result["request"])
                             print_query(input_text)

--- a/benchmark/benchmark/main.py
+++ b/benchmark/benchmark/main.py
@@ -61,9 +61,9 @@ async def main() -> None:
 
     # Loop through models first, then run all agents for each model
     for model in original_models:
-        console.print(f"\n[bold cyan]{'='*80}[/bold cyan]")
+        console.print(f"\n[bold cyan]{'=' * 80}[/bold cyan]")
         console.print(f"[bold cyan]Testing Model: {model}[/bold cyan]")
-        console.print(f"[bold cyan]{'='*80}[/bold cyan]\n")
+        console.print(f"[bold cyan]{'=' * 80}[/bold cyan]\n")
 
         # Warm up the model before benchmarking to exclude loading time
         console.print(f"[dim yellow]🔥 Warming up {model}...[/dim yellow]", end=" ")
@@ -80,6 +80,7 @@ async def main() -> None:
 
         # Temporarily set BENCHMARK_MODELS to single model
         import benchmark.config as config
+
         config.BENCHMARK_MODELS = [model]
 
         # Run all agent tests for this model
@@ -109,6 +110,7 @@ async def main() -> None:
 
     # Restore original BENCHMARK_MODELS
     import benchmark.config as config
+
     config.BENCHMARK_MODELS = original_models
 
     total_duration = time.perf_counter() - benchmark_start_time

--- a/benchmark/benchmark/metrics.py
+++ b/benchmark/benchmark/metrics.py
@@ -61,15 +61,10 @@ class MetricsCollector:
         )
 
         self.results.append(result)
-        logger.debug(
-            f"Recorded: {agent} ({model}) - {latency_ms:.2f}ms, "
-            f"success={success}, memory_delta={memory_delta:.2f}MB"
-        )
+        logger.debug(f"Recorded: {agent} ({model}) - {latency_ms:.2f}ms, success={success}, memory_delta={memory_delta:.2f}MB")
         return result
 
-    def get_summary(
-        self, model: str, agent: str
-    ) -> BenchmarkSummary | None:
+    def get_summary(self, model: str, agent: str) -> BenchmarkSummary | None:
         """
         Get summary statistics for a model/agent combination.
 
@@ -80,11 +75,7 @@ class MetricsCollector:
         Returns:
             BenchmarkSummary or None if no results
         """
-        results = [
-            r
-            for r in self.results
-            if r.model == model and r.agent == agent
-        ]
+        results = [r for r in self.results if r.model == model and r.agent == agent]
 
         if not results:
             return None
@@ -104,14 +95,9 @@ class MetricsCollector:
             return latencies_sorted[min(idx, n - 1)]
 
         memory_deltas = [r.memory_delta_mb for r in successful]
-        memory_mean = (
-            statistics.mean(memory_deltas) if memory_deltas else 0.0
-        )
+        memory_mean = statistics.mean(memory_deltas) if memory_deltas else 0.0
 
-        total_time_s = (
-            max(r.timestamp for r in results).timestamp()
-            - min(r.timestamp for r in results).timestamp()
-        )
+        total_time_s = max(r.timestamp for r in results).timestamp() - min(r.timestamp for r in results).timestamp()
         rps = len(results) / max(total_time_s, 1.0)
 
         return BenchmarkSummary(
@@ -124,11 +110,7 @@ class MetricsCollector:
             latency_ms_p95=percentile(95),
             latency_ms_p99=percentile(99),
             latency_ms_mean=statistics.mean(latencies),
-            latency_ms_std=(
-                statistics.stdev(latencies)
-                if len(latencies) > 1
-                else 0.0
-            ),
+            latency_ms_std=(statistics.stdev(latencies) if len(latencies) > 1 else 0.0),
             memory_delta_mb_mean=memory_mean,
             error_rate=len(failed) / len(results) if results else 0.0,
             requests_per_second=rps,
@@ -177,27 +159,14 @@ class MetricsCollector:
 
             for agent_name, summary in agents.items():
                 print(f"\n  Agent: {agent_name}")
-                print(
-                    f"    Requests: {summary.total_requests} "
-                    f"(✓ {summary.successful_requests}, "
-                    f"✗ {summary.failed_requests})"
-                )
-                print(
-                    f"    Error Rate: {summary.error_rate * 100:.2f}%"
-                )
+                print(f"    Requests: {summary.total_requests} (✓ {summary.successful_requests}, ✗ {summary.failed_requests})")
+                print(f"    Error Rate: {summary.error_rate * 100:.2f}%")
                 print("    Latency (ms):")
                 print(f"      p50: {summary.latency_ms_p50:.2f}")
                 print(f"      p95: {summary.latency_ms_p95:.2f}")
                 print(f"      p99: {summary.latency_ms_p99:.2f}")
-                print(
-                    f"      mean: {summary.latency_ms_mean:.2f} "
-                    f"(σ={summary.latency_ms_std:.2f})"
-                )
-                print(
-                    f"    Memory Delta: {summary.memory_delta_mb_mean:.2f} MB"
-                )
-                print(
-                    f"    Throughput: {summary.requests_per_second:.2f} req/s"
-                )
+                print(f"      mean: {summary.latency_ms_mean:.2f} (σ={summary.latency_ms_std:.2f})")
+                print(f"    Memory Delta: {summary.memory_delta_mb_mean:.2f} MB")
+                print(f"    Throughput: {summary.requests_per_second:.2f} req/s")
 
         print("\n" + "=" * 80)

--- a/benchmark/benchmark/resources.py
+++ b/benchmark/benchmark/resources.py
@@ -78,13 +78,9 @@ class ResourceTracker:
             util = gpu_metrics.get("gpu_util")
             vram_mb = gpu_metrics.get("vram_used_mb")
             if util is not None:
-                self.gpu_util_max = util if self.gpu_util_max is None else max(
-                    self.gpu_util_max, util
-                )
+                self.gpu_util_max = util if self.gpu_util_max is None else max(self.gpu_util_max, util)
             if vram_mb is not None:
-                self.vram_max_mb = vram_mb if self.vram_max_mb is None else max(
-                    self.vram_max_mb, vram_mb
-                )
+                self.vram_max_mb = vram_mb if self.vram_max_mb is None else max(self.vram_max_mb, vram_mb)
 
     def start_continuous_sampling(self, interval: float = 0.1) -> None:
         """Start a background thread that samples resources continuously."""

--- a/benchmark/benchmark/ui.py
+++ b/benchmark/benchmark/ui.py
@@ -30,18 +30,12 @@ def print_endpoint_header(endpoint: str, num_requests: int) -> None:
     console.print(f"\n[bold blue]📊 {endpoint} ({num_requests} requests):[/bold blue]")
 
 
-def print_request_result(
-    request_num: int, latency_ms: float, success: bool, error: str | None = None
-) -> None:
+def print_request_result(request_num: int, latency_ms: float, success: bool, error: str | None = None) -> None:
     """Print request result with status indicator."""
     if success:
-        console.print(
-            f"  [dim]Request {request_num}:[/dim] {latency_ms:.2f}ms [green]✓[/green]"
-        )
+        console.print(f"  [dim]Request {request_num}:[/dim] {latency_ms:.2f}ms [green]✓[/green]")
     else:
-        console.print(
-            f"  [dim]Request {request_num}:[/dim] [red]✗ FAILED[/red] - {error or 'Unknown'}"
-        )
+        console.print(f"  [dim]Request {request_num}:[/dim] [red]✗ FAILED[/red] - {error or 'Unknown'}")
 
 
 def print_query(query: str) -> None:

--- a/common-ai/common_ai/agent_models.py
+++ b/common-ai/common_ai/agent_models.py
@@ -22,15 +22,9 @@ class AgentRequest(BaseModel):
     """Request sent to a specialized agent"""
 
     query: str = Field(..., description="User query to analyze")
-    time_range: str = Field(
-        default="1h", description="Time range for analysis (e.g., '1h', '24h', '7d')"
-    )
-    context: dict[str, Any] = Field(
-        default_factory=dict, description="Additional context for the agent"
-    )
-    timestamp: datetime = Field(
-        default_factory=datetime.now, description="Request timestamp"
-    )
+    time_range: str = Field(default="1h", description="Time range for analysis (e.g., '1h', '24h', '7d')")
+    context: dict[str, Any] = Field(default_factory=dict, description="Additional context for the agent")
+    timestamp: datetime = Field(default_factory=datetime.now, description="Request timestamp")
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -46,25 +40,13 @@ class AgentRequest(BaseModel):
 class AgentResponse(BaseModel):
     """Response from a specialized agent"""
 
-    agent_name: AgentType = Field(
-        ..., description="Name of the agent that produced this response"
-    )
+    agent_name: AgentType = Field(..., description="Name of the agent that produced this response")
     analysis: str = Field(..., description="Natural language analysis of the findings")
-    data: dict[str, Any] = Field(
-        default_factory=dict, description="Structured data supporting the analysis"
-    )
-    confidence: float = Field(
-        default=0.5, ge=0.0, le=1.0, description="Confidence score (0-1)"
-    )
-    grafana_links: list[str] = Field(
-        default_factory=list, description="Links to Grafana dashboards/queries"
-    )
-    timestamp: datetime = Field(
-        default_factory=datetime.now, description="Response timestamp"
-    )
-    error: Optional[str] = Field(
-        default=None, description="Error message if analysis failed"
-    )
+    data: dict[str, Any] = Field(default_factory=dict, description="Structured data supporting the analysis")
+    confidence: float = Field(default=0.5, ge=0.0, le=1.0, description="Confidence score (0-1)")
+    grafana_links: list[str] = Field(default_factory=list, description="Links to Grafana dashboards/queries")
+    timestamp: datetime = Field(default_factory=datetime.now, description="Response timestamp")
+    error: Optional[str] = Field(default=None, description="Error message if analysis failed")
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -91,15 +73,9 @@ class OrchestratorResponse(BaseModel):
 
     query: str = Field(..., description="Original user query")
     summary: str = Field(..., description="Synthesized summary of all agent analyses")
-    agent_responses: dict[str, AgentResponse] = Field(
-        ..., description="Individual responses from each agent"
-    )
-    recommendations: list[str] = Field(
-        default_factory=list, description="Actionable recommendations"
-    )
-    timestamp: datetime = Field(
-        default_factory=datetime.now, description="Response timestamp"
-    )
+    agent_responses: dict[str, AgentResponse] = Field(..., description="Individual responses from each agent")
+    recommendations: list[str] = Field(default_factory=list, description="Actionable recommendations")
+    timestamp: datetime = Field(default_factory=datetime.now, description="Response timestamp")
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/common-ai/common_ai/llm_config.py
+++ b/common-ai/common_ai/llm_config.py
@@ -31,10 +31,7 @@ def load_model_params_config() -> dict:
 
     # Try multiple paths (development, docker, installed package)
     possible_paths = [
-        Path(__file__).parent.parent.parent
-        / "config"
-        / "ai"
-        / "model-params.yml",  # From common-ai in workspace
+        Path(__file__).parent.parent.parent / "config" / "ai" / "model-params.yml",  # From common-ai in workspace
         Path("/app/config/ai/model-params.yml"),  # Docker container
         Path.cwd() / "config" / "ai" / "model-params.yml",  # Current directory
     ]
@@ -84,12 +81,8 @@ def get_model_params(model_name: str) -> dict:
             return models_config[config_key]
 
     # Fallback to default
-    default_params = config.get(
-        "default", {"temperature": 0.1, "top_k": None, "max_tokens": 2000}
-    )
-    logger.warning(
-        f"No specific config found for model '{model_name}', using default: {default_params}"
-    )
+    default_params = config.get("default", {"temperature": 0.1, "top_k": None, "max_tokens": 2000})
+    logger.warning(f"No specific config found for model '{model_name}', using default: {default_params}")
     return default_params
 
 
@@ -115,9 +108,7 @@ class SafeChatOpenAI(ChatOpenAI):
             return super().invoke(input, *args, **kwargs)
         except AttributeError as e:
             if "'LegacyAPIResponse' object has no attribute 'model'" in str(e):
-                logger.warning(
-                    f"OpenTelemetry instrumentation error (response was generated): {e}"
-                )
+                logger.warning(f"OpenTelemetry instrumentation error (response was generated): {e}")
                 # Response was actually generated; error only in instrumentation
                 raise
             else:
@@ -193,12 +184,8 @@ def get_llm(
     if top_k is None:
         top_k = model_config.get("top_k")
 
-    logger.info(
-        f"Creating LLM instance: model={model_name}, base_url={base_url}, temp={temperature}, top_k={top_k}, max_tokens={max_tokens}"
-    )
-    logger.debug(
-        f"get_llm() called with model parameter={model}, final model_name={model_name}"
-    )
+    logger.info(f"Creating LLM instance: model={model_name}, base_url={base_url}, temp={temperature}, top_k={top_k}, max_tokens={max_tokens}")
+    logger.debug(f"get_llm() called with model parameter={model}, final model_name={model_name}")
 
     # Build model_kwargs for Ollama-specific parameters
     model_kwargs: dict[str, Any] = {}

--- a/common-ai/common_ai/llm_utils.py
+++ b/common-ai/common_ai/llm_utils.py
@@ -22,7 +22,7 @@ def extract_text_from_response(response: object) -> str:
             content = response.content
             if content is not None:
                 return str(content)
-    except (AttributeError, Exception):
+    except AttributeError, Exception:
         pass
 
     # Try text attribute (alternative)
@@ -31,7 +31,7 @@ def extract_text_from_response(response: object) -> str:
             text = response.text
             if text is not None:
                 return str(text)
-    except (AttributeError, Exception):
+    except AttributeError, Exception:
         pass
 
     # Fallback to string representation

--- a/common-ai/common_ai/mcp_client.py
+++ b/common-ai/common_ai/mcp_client.py
@@ -62,14 +62,10 @@ class MCPGrafanaClient:
 
             # Connect to MCP server via SSE
             logger.info(f"Connecting to MCP server at {self.base_url}/sse")
-            read_stream, write_stream = await self._exit_stack.enter_async_context(
-                sse_client(f"{self.base_url}/sse")
-            )
+            read_stream, write_stream = await self._exit_stack.enter_async_context(sse_client(f"{self.base_url}/sse"))
 
             # Create MCP session
-            self._session = await self._exit_stack.enter_async_context(
-                ClientSession(read_stream, write_stream)
-            )
+            self._session = await self._exit_stack.enter_async_context(ClientSession(read_stream, write_stream))
 
             # Initialize the session
             await self._session.initialize()
@@ -145,19 +141,13 @@ class MCPGrafanaClient:
 
                             if ds_type == "loki" and not self.loki_uid:
                                 self.loki_uid = ds_uid
-                                logger.info(
-                                    f"Found Loki datasource: {ds_name} (uid: {ds_uid})"
-                                )
+                                logger.info(f"Found Loki datasource: {ds_name} (uid: {ds_uid})")
                             elif ds_type == "prometheus" and not self.prometheus_uid:
                                 self.prometheus_uid = ds_uid
-                                logger.info(
-                                    f"Found Prometheus/Mimir datasource: {ds_name} (uid: {ds_uid})"
-                                )
+                                logger.info(f"Found Prometheus/Mimir datasource: {ds_name} (uid: {ds_uid})")
                             elif ds_type == "tempo" and not self.tempo_uid:
                                 self.tempo_uid = ds_uid
-                                logger.info(
-                                    f"Found Tempo datasource: {ds_name} (uid: {ds_uid})"
-                                )
+                                logger.info(f"Found Tempo datasource: {ds_name} (uid: {ds_uid})")
 
         except Exception as e:
             logger.warning(f"Failed to fetch datasource UIDs: {e}")
@@ -409,13 +399,8 @@ class MCPGrafanaClient:
         except Exception as e:
             error_msg = str(e)
             # If tool not found, it means proxied tools are disabled
-            if (
-                "tempo_traceql-search" in error_msg.lower()
-                or "unknown tool" in error_msg.lower()
-            ):
-                logger.warning(
-                    "Tempo proxied tools not available. Enable with MCP server flag."
-                )
+            if "tempo_traceql-search" in error_msg.lower() or "unknown tool" in error_msg.lower():
+                logger.warning("Tempo proxied tools not available. Enable with MCP server flag.")
                 return {
                     "error": "Tempo tools not available - proxied tools may be disabled in MCP server",
                     "traces": [],
@@ -607,9 +592,7 @@ class MCPGrafanaClient:
             logger.error(f"Failed to list Prometheus metric names: {e}")
             return []
 
-    async def list_prometheus_metric_metadata(
-        self, metric: str | None = None
-    ) -> dict[str, Any]:
+    async def list_prometheus_metric_metadata(self, metric: str | None = None) -> dict[str, Any]:
         """
         Get metadata for Prometheus metrics (type, help, unit)
 
@@ -630,9 +613,7 @@ class MCPGrafanaClient:
             if metric:
                 arguments["metric"] = metric
 
-            result = await session.call_tool(
-                "list_prometheus_metric_metadata", arguments=arguments
-            )
+            result = await session.call_tool("list_prometheus_metric_metadata", arguments=arguments)
 
             return self._parse_mcp_result(result)
 
@@ -670,9 +651,7 @@ class MCPGrafanaClient:
             logger.error(f"Failed to list Prometheus label names: {e}")
             return []
 
-    async def list_prometheus_label_values(
-        self, label_name: str, metric: str | None = None
-    ) -> list[str]:
+    async def list_prometheus_label_values(self, label_name: str, metric: str | None = None) -> list[str]:
         """
         List all values for a specific Prometheus label
 
@@ -697,9 +676,7 @@ class MCPGrafanaClient:
             if metric:
                 arguments["metric"] = metric
 
-            result = await session.call_tool(
-                "list_prometheus_label_values", arguments=arguments
-            )
+            result = await session.call_tool("list_prometheus_label_values", arguments=arguments)
 
             data = self._parse_mcp_result(result)
             if isinstance(data, list):
@@ -709,9 +686,7 @@ class MCPGrafanaClient:
             return []
 
         except Exception as e:
-            logger.error(
-                f"Failed to list Prometheus label values for '{label_name}': {e}"
-            )
+            logger.error(f"Failed to list Prometheus label values for '{label_name}': {e}")
             return []
 
     async def list_alert_rules(self) -> list[dict[str, Any]]:
@@ -750,9 +725,7 @@ class MCPGrafanaClient:
         try:
             session = await self._ensure_session()
 
-            result = await session.call_tool(
-                "get_alert_rule_by_uid", arguments={"uid": uid}
-            )
+            result = await session.call_tool("get_alert_rule_by_uid", arguments={"uid": uid})
 
             return self._parse_mcp_result(result)
 
@@ -789,14 +762,8 @@ class MCPGrafanaClient:
             # Convert RFC3339 to milliseconds timestamp
             from datetime import datetime
 
-            start_ms = int(
-                datetime.fromisoformat(start_rfc.replace("Z", "+00:00")).timestamp()
-                * 1000
-            )
-            end_ms = int(
-                datetime.fromisoformat(end_rfc.replace("Z", "+00:00")).timestamp()
-                * 1000
-            )
+            start_ms = int(datetime.fromisoformat(start_rfc.replace("Z", "+00:00")).timestamp() * 1000)
+            end_ms = int(datetime.fromisoformat(end_rfc.replace("Z", "+00:00")).timestamp() * 1000)
 
             arguments = {
                 "from": start_ms,

--- a/common-ai/common_ai/ollama_utils.py
+++ b/common-ai/common_ai/ollama_utils.py
@@ -95,7 +95,7 @@ async def load_ollama_model(model_name: str) -> bool:
             "stream": False,
             "options": {
                 "num_predict": 1,  # Only generate 1 token for fast warm-up
-            }
+            },
         }
 
         async with httpx.AsyncClient(timeout=30.0) as client:

--- a/customer/customer/customer_producer.py
+++ b/customer/customer/customer_producer.py
@@ -26,15 +26,11 @@ def delivery_report(err, msg):
 
 
 # Initialize the Kafka producer
-producer = Producer(
-    {"bootstrap.servers": os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")}
-)
+producer = Producer({"bootstrap.servers": os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")})
 
 
 def send_order(order: Order):
-    producer.produce(
-        "orders", value=json.dumps(order.model_dump()), callback=delivery_report
-    )
+    producer.produce("orders", value=json.dumps(order.model_dump()), callback=delivery_report)
     producer.poll(0)
 
 

--- a/order/order/crud.py
+++ b/order/order/crud.py
@@ -22,19 +22,11 @@ def get_orders(db: Session, skip: int = 0, limit: int = 10):
     return db.query(models.Order).offset(skip).limit(limit).all()
 
 
-def get_orders_by_status(
-    db: Session, order_status: OrderStatus, skip: int = 0, limit: int = 10
-):
+def get_orders_by_status(db: Session, order_status: OrderStatus, skip: int = 0, limit: int = 10):
     """
     Retrieve a list of orders by status with optional pagination.
     """
-    return (
-        db.query(models.Order)
-        .filter(models.Order.order_status == order_status)
-        .offset(skip)
-        .limit(limit)
-        .all()
-    )
+    return db.query(models.Order).filter(models.Order.order_status == order_status).offset(skip).limit(limit).all()
 
 
 def update_order_status(db: Session, order_id: int, order_status: OrderStatus):

--- a/order/order/database.py
+++ b/order/order/database.py
@@ -6,9 +6,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 # Define the database URL here
-DATABASE_URL = os.environ.get(
-    "DATABASE_URL", "postgresql://postgres:yourpassword@localhost:5432/mydatabase"
-)
+DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://postgres:yourpassword@localhost:5432/mydatabase")
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/order/order/models.py
+++ b/order/order/models.py
@@ -29,15 +29,7 @@ class Order(db.Model):
     def to_dict(self):
         return {
             "id": self.id,
-            "wood_type": (
-                self.wood_type.value
-                if hasattr(self.wood_type, "value")
-                else self.wood_type
-            ),
+            "wood_type": (self.wood_type.value if hasattr(self.wood_type, "value") else self.wood_type),
             "quantity": self.quantity,
-            "order_status": (
-                self.order_status.value
-                if hasattr(self.order_status, "value")
-                else self.order_status
-            ),
+            "order_status": (self.order_status.value if hasattr(self.order_status, "value") else self.order_status),
         }

--- a/order/order/routes/orders.py
+++ b/order/order/routes/orders.py
@@ -30,17 +30,11 @@ MSG_ERROR_NOT_FOUND = "Order not found"
 @orders_bp.after_request
 def log_response(response):
     if response.status_code >= 500:
-        current_app.logger.error(
-            f"HTTP {response.status_code} error for {request.method} {request.path}"
-        )
+        current_app.logger.error(f"HTTP {response.status_code} error for {request.method} {request.path}")
     elif response.status_code >= 400:
-        current_app.logger.warning(
-            f"HTTP {response.status_code} client error for {request.method} {request.path}"
-        )
+        current_app.logger.warning(f"HTTP {response.status_code} client error for {request.method} {request.path}")
     elif 200 <= response.status_code < 300:
-        current_app.logger.info(
-            f"HTTP {response.status_code} success for {request.method} {request.path}"
-        )
+        current_app.logger.info(f"HTTP {response.status_code} success for {request.method} {request.path}")
     return response
 
 
@@ -209,9 +203,7 @@ def read_orders_by_status_route(status):
 
     db = SessionLocal()
     try:
-        orders = get_orders_by_status(
-            db=db, order_status=OrderStatus(status), skip=skip, limit=limit
-        )
+        orders = get_orders_by_status(db=db, order_status=OrderStatus(status), skip=skip, limit=limit)
         return jsonify([order.to_dict() for order in orders])
     except Exception:
         current_app.logger.exception("Unexpected error during order list by status")
@@ -334,9 +326,7 @@ def update_order_status_route(order_id):
         if order is None:
             return jsonify({"error": "Order not found"}), 404
 
-        updated_order = update_order_status(
-            db, order_id=order_id, order_status=order_status
-        )
+        updated_order = update_order_status(db, order_id=order_id, order_status=order_status)
 
         if updated_order is None:
             return jsonify({"error": "Order not found"}), 404

--- a/order/order/schemas.py
+++ b/order/order/schemas.py
@@ -49,6 +49,4 @@ class Order(OrderBase):
             from_attributes (bool): Config option to load attributes from the model's attributes.
         """
 
-        from_attributes = (
-            True  # Config option to load attributes from the model's attributes
-        )
+        from_attributes = True  # Config option to load attributes from the model's attributes

--- a/ordercheck/ordercheck/ordercheck_consumer.py
+++ b/ordercheck/ordercheck/ordercheck_consumer.py
@@ -18,9 +18,7 @@ logger.setLevel(getattr(logging, log_level, logging.INFO))
 # Initialize the Kafka consumer
 consumer = Consumer(
     {
-        "bootstrap.servers": os.environ.get(
-            "KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"
-        ),
+        "bootstrap.servers": os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
         "group.id": "order-check-group",
         "auto.offset.reset": "earliest",
     }

--- a/ordermanagement/ordermanagement/ordermanagement.py
+++ b/ordermanagement/ordermanagement/ordermanagement.py
@@ -37,9 +37,7 @@ def fetch_registered_orders():
 
 def decrease_stock(order):
     payload = {"wood_type": order["wood_type"], "quantity": order["quantity"]}
-    response = requests.post(
-        API_URL_STOCKS_DECREASE, headers=HEADERS_JSON, json=payload
-    )
+    response = requests.post(API_URL_STOCKS_DECREASE, headers=HEADERS_JSON, json=payload)
     if response.status_code == 400:
         raise Exception("Insufficient stock")
     if response.status_code == 404:
@@ -51,9 +49,7 @@ def decrease_stock(order):
 def update_order_status(order_id, status):
     payload = {"order_status": status.value if hasattr(status, "value") else status}
     try:
-        response = requests.put(
-            f"{API_URL_ORDERS_UPDATE}/{order_id}", headers=HEADERS_JSON, json=payload
-        )
+        response = requests.put(f"{API_URL_ORDERS_UPDATE}/{order_id}", headers=HEADERS_JSON, json=payload)
         response.raise_for_status()
         return response.json()
     except requests.RequestException as e:
@@ -121,9 +117,7 @@ def process_registered_order():
 if __name__ == "__main__":
     interval_seconds = int(os.getenv("INTERVAL_SECONDS", 60))
 
-    logger.info(
-        "Starting order management service with %d seconds interval", interval_seconds
-    )
+    logger.info("Starting order management service with %d seconds interval", interval_seconds)
 
     while True:
         process_registered_order()

--- a/stock/stock/crud.py
+++ b/stock/stock/crud.py
@@ -10,9 +10,7 @@ def get_stocks(db: Session, skip: int = 0, limit: int = 10):
 
 
 def create_stock(db: Session, stock: schemas.StockCreate):
-    db_stock = (
-        db.query(models.Stock).filter(models.Stock.wood_type == stock.wood_type).first()
-    )
+    db_stock = db.query(models.Stock).filter(models.Stock.wood_type == stock.wood_type).first()
 
     if db_stock:
         # Update existing stock

--- a/stock/stock/database.py
+++ b/stock/stock/database.py
@@ -6,9 +6,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 # Define the database URL here
-DATABASE_URL = os.environ.get(
-    "DATABASE_URL", "postgresql://postgres:yourpassword@localhost:5432/mydatabase"
-)
+DATABASE_URL = os.environ.get("DATABASE_URL", "postgresql://postgres:yourpassword@localhost:5432/mydatabase")
 
 engine = create_engine(DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/stock/stock/models.py
+++ b/stock/stock/models.py
@@ -8,9 +8,7 @@ from .database import db
 class Stock(db.Model):
     __tablename__ = "stocks"
 
-    wood_type = Column(
-        Enum(WoodType), nullable=False, primary_key=True, index=True, unique=True
-    )
+    wood_type = Column(Enum(WoodType), nullable=False, primary_key=True, index=True, unique=True)
     quantity = Column(Integer, nullable=False)
 
     def to_dict(self):

--- a/stock/stock/routes/stocks.py
+++ b/stock/stock/routes/stocks.py
@@ -30,17 +30,11 @@ MSG_ERROR_NOT_FOUND = "Stock not found"
 @stocks_bp.after_request
 def log_response(response):
     if response.status_code >= 500:
-        current_app.logger.error(
-            f"HTTP {response.status_code} error for {request.method} {request.path}"
-        )
+        current_app.logger.error(f"HTTP {response.status_code} error for {request.method} {request.path}")
     elif response.status_code >= 400:
-        current_app.logger.warning(
-            f"HTTP {response.status_code} client error for {request.method} {request.path}"
-        )
+        current_app.logger.warning(f"HTTP {response.status_code} client error for {request.method} {request.path}")
     elif 200 <= response.status_code < 300:
-        current_app.logger.info(
-            f"HTTP {response.status_code} success for {request.method} {request.path}"
-        )
+        current_app.logger.info(f"HTTP {response.status_code} success for {request.method} {request.path}")
     return response
 
 
@@ -249,9 +243,7 @@ def decrease_stock_route():
         return jsonify({"error": "Insufficient stock"}), 400
 
     try:
-        decrease_stock_quantity(
-            db, wood_type=stock_data.wood_type, quantity=stock_data.quantity
-        )
+        decrease_stock_quantity(db, wood_type=stock_data.wood_type, quantity=stock_data.quantity)
         db.commit()
         db.refresh(db_stock)
     except Exception:

--- a/stock/stock/schemas.py
+++ b/stock/stock/schemas.py
@@ -18,6 +18,4 @@ class Stock(StockBase):
 
 class StockDecrease(BaseModel):
     wood_type: str
-    quantity: int = Field(
-        gt=0, description="Quantity to decrease, must be greater than zero"
-    )
+    quantity: int = Field(gt=0, description="Quantity to decrease, must be greater than zero")

--- a/supplier/supplier/supplier_producer.py
+++ b/supplier/supplier/supplier_producer.py
@@ -26,15 +26,11 @@ def delivery_report(err, msg):
 
 
 # Initialize the Kafka producer
-producer = Producer(
-    {"bootstrap.servers": os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")}
-)
+producer = Producer({"bootstrap.servers": os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")})
 
 
 def send_stock(stock: Stock):
-    producer.produce(
-        "stocks", value=json.dumps(stock.model_dump()), callback=delivery_report
-    )
+    producer.produce("stocks", value=json.dumps(stock.model_dump()), callback=delivery_report)
     producer.poll(0)
 
 

--- a/suppliercheck/suppliercheck/suppliercheck_consumer.py
+++ b/suppliercheck/suppliercheck/suppliercheck_consumer.py
@@ -18,9 +18,7 @@ logger.setLevel(getattr(logging, log_level, logging.INFO))
 # Initialize the Kafka consumer
 consumer = Consumer(
     {
-        "bootstrap.servers": os.environ.get(
-            "KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"
-        ),
+        "bootstrap.servers": os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
         "group.id": "stock-check-group",
         "auto.offset.reset": "earliest",
     }


### PR DESCRIPTION
## Summary

Builds on PR #26 (import ordering, `line-length=200`) with the remaining lint improvements:

- Apply `ruff format` consistently across all 50 files (un-applied in #26)
- Replace deprecated `typing.List` with built-in `list` (Python 3.9+) in `agent-ui`
- Move local `from datetime import datetime` to module level in `agent-orchestrator/orchestrator.py`
- Update `CLAUDE.md` to reflect `line-length=200` (was incorrectly documented as 100)

## Scope note

Touches DRAFT services (`agent-logs`, `agent-metrics`, `agent-orchestrator`, `agent-traces`, `agent-ui`) and KEEPER services — formatting only, no logic modified.

## Test plan

- [x] `make lint` passes with no errors (verified locally)
- [x] Single clean commit on top of main — no contradictory history
- [x] No functional changes — `ruff format` + targeted import/type fixes only
- [x] `CLAUDE.md` aligned with actual `pyproject.toml` configuration
- [x] No implicit string concatenations
- [x] `typing.List` → `list` in `agent-ui`