### PR TITLE
feat(testing): add smoke tests for KEEPER services and make test target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,19 +41,27 @@ Two-layer model:
 - **Python 3.14+** and **UV** — see `.github/instructions/python.instructions.md` for full conventions.
   Critical rule: always `uv run <cmd>`, never call `python`/`pip`/`pytest` directly.
 - **Docker Compose** — 7 split files orchestrated via `Makefile`
-- **Ruff** — linting, line-length=200, rules: E, F, W, I (configured in root `pyproject.toml`)
-- **Black** — formatting (`uvx ruff check <project>` / `uv run black <project>`)
+- **Ruff** — linting and formatting, line-length=200, rules: E, F, W, I (configured in root `pyproject.toml`)
 - **Pyright** — type checking
 
 ## Key Makefile Targets
 
 ```bash
-make compose-up     # Start full stack (observability → db → kafka → ai-tools → ai → apps → traefik)
-make compose-down   # Stop all services (reverse order)
-make lint           # Ruff check across all 14 projects
-make tools-format   # Black format across all projects
-make models-init    # Pull Ollama AI models (mistral, llama, qwen, etc.)
+make compose-up       # Start full stack (observability → db → kafka → ai-tools → ai → apps → traefik)
+make compose-down     # Stop all services (reverse order)
+make lint             # Ruff check across all projects (PROJECTS var — includes agents)
+make tools-format     # Ruff format across all projects (runs from repo root, applies root pyproject.toml config)
+make models-init      # Pull Ollama AI models (mistral, llama, qwen, etc.)
+make test             # test-lint + test-unit + test-integration (stops on first failure; use make -k to run all)
+make test-lint        # Ruff check scoped to KEEPER_SERVICES only (subset of make lint)
+make test-unit        # Pytest smoke tests — KEEPER_SERVICES only (7 dirs), no Docker required
+make test-integration # Container health checks (order, stock only) — skips if stack not running or runtime absent; unhealthy containers report failure
 ```
+
+> **Makefile variable scopes:** `PROJECTS` = all services (see Makefile for the full list), used by `make lint`.
+> `KEEPER_SERVICES` (7 dirs) = business services with runnable processes, used by `make test-lint` and `make test-unit`.
+> `HEALTHCHECK_SERVICES` (2 dirs) = `order` and `stock` — only Flask services with container healthchecks, used by the `test-integration` health loop.
+> Agent services (`agent-*`) and shared libs (`common-*`) are in `PROJECTS` but not `KEEPER_SERVICES`.
 
 ## Environment Setup
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,21 @@
-.PHONY: models-init tools-format lint compose-up compose-down
+.PHONY: models-init tools-format lint compose-up compose-down test test-lint test-unit test-integration
 
 # Models to pull
 MODELS := mistral:7b llama3.2:3b qwen3:0.6b granite4:3b mistral-nemo:12b qwen2.5:7b phi4:14b
 
+# All service directories — used by lint (ruff) and tools-format (ruff format).
+# Includes agent/benchmark services that have no smoke tests.
 PROJECTS := agent-logs agent-metrics agent-orchestrator agent-traces agent-ui agent-traduction benchmark common-ai common-models customer order ordercheck ordermanagement stock supplier suppliercheck
+# Business services with runnable Python processes and a tests/ directory.
+# Shared libraries (common-models, common-ai) are excluded — they have no executable entry point.
+# Scope: make test-lint and make test-unit. For full lint use PROJECTS (all 16 dirs).
+KEEPER_SERVICES := customer order ordercheck ordermanagement stock supplier suppliercheck
+# Subset of KEEPER_SERVICES with a container healthcheck defined in docker-compose-apps.yml.
+# Only Flask REST APIs (order, stock) have healthchecks — Kafka producers/consumers and workers do not.
+# WARNING: only add a service here if docker-compose-apps.yml defines a HEALTHCHECK for it;
+# otherwise the integration check will always report "unknown" and fail.
+# Scope: make test-integration health loop only.
+HEALTHCHECK_SERVICES := order stock
 
 # Detect container runtime (docker or podman)
 DOCKER_AVAILABLE := $(shell command -v docker >/dev/null 2>&1 && echo true || echo false)
@@ -42,16 +54,75 @@ models-init:
 	done; \
 	echo "models-init: done"
 
+# Scoped lint on KEEPER services, then smoke tests, then integration.
+# Use 'make lint' for full project lint. Use 'make -k test' to run all phases on failure.
+test: test-lint test-unit test-integration
+
+test-lint:
+	@echo "Linting KEEPER services..."
+	@uvx ruff check $(KEEPER_SERVICES)
+
+test-unit:
+	@echo "Running smoke tests for KEEPER services..."
+	@failed=0; total_tests=0; \
+	for svc in $(KEEPER_SERVICES); do \
+		printf "  %-20s" "$$svc"; \
+		output=$$(cd $$svc 2>&1 && timeout 60 uv run pytest tests/ -q --tb=short 2>&1); \
+		exitcode=$$?; \
+		if [ $$exitcode -eq 0 ]; then \
+			tcount=$$(echo "$$output" | sed -n 's/^\([0-9]\+\) passed.*/\1/p' | head -1); \
+			total_tests=$$((total_tests + $${tcount:-0})); \
+			echo "✓ ($${tcount:-?} passed)"; \
+		elif [ $$exitcode -eq 124 ]; then \
+			echo "✗ (timeout >60s)"; \
+			printf "  === %s ===\n" "$$svc"; \
+			echo "$$output" | sed 's/^/  /'; \
+			failed=$$((failed+1)); \
+		elif [ $$exitcode -eq 5 ]; then \
+			echo "✗ (no tests found — add tests to tests/)"; \
+			printf "  === %s ===\n" "$$svc"; \
+			echo "$$output" | sed 's/^/  /'; \
+			failed=$$((failed+1)); \
+		else \
+			echo "✗"; \
+			printf "  === %s ===\n" "$$svc"; \
+			echo "$$output" | sed 's/^/  /'; \
+			failed=$$((failed+1)); \
+		fi; \
+	done; \
+	if [ $$failed -eq 0 ]; then echo "All smoke tests passed ($$total_tests tests)"; else echo "$$failed service(s) failed; $$total_tests tests passed in services that passed"; exit 1; fi
+
+test-integration:
+	@echo "Checking container health for $(HEALTHCHECK_SERVICES) (requires running stack)..."
+	@# Only HEALTHCHECK_SERVICES (order, stock) have container healthchecks; Kafka services and workers do not.
+	@# grep searches STATUS column values: Up/running/healthy/unhealthy/starting; service names don't contain these words.
+	@# Health check JSON parsing assumes Docker/Compose --format json output; format varies by version.
+	@if [ "$(DOCKER_AVAILABLE)" = "false" ] && [ "$(PODMAN_AVAILABLE)" = "false" ]; then \
+		echo "  No container runtime found (docker/podman) — skipping integration checks"; \
+		exit 0; \
+	fi; \
+	if ! $(COMPOSE_CMD) -f docker-compose/docker-compose-apps.yml ps $(HEALTHCHECK_SERVICES) 2>/dev/null | grep -qE "\b(Up|running|healthy|unhealthy|starting)\b"; then \
+		echo "  Services $(HEALTHCHECK_SERVICES) not running — skipping integration checks (run make compose-up first)"; \
+		exit 0; \
+	fi; \
+	failed=0; \
+	for svc in $(HEALTHCHECK_SERVICES); do \
+		printf "  %-20s" "$$svc"; \
+		status=$$($(COMPOSE_CMD) -f docker-compose/docker-compose-apps.yml ps $$svc --format json 2>/dev/null | tr -d '\n' | sed -n 's/.*"Health":"\([^"]*\)".*/\1/p'); \
+		status=$${status:-unknown}; \
+		if [ "$$status" = "healthy" ]; then echo "✓ healthy"; \
+		elif [ "$$status" = "unknown" ]; then echo "✗ unknown (no HEALTHCHECK instruction in docker-compose-apps.yml for $$svc — run: docker inspect $$svc | grep -A5 Health)"; failed=$$((failed+1)); \
+		else echo "✗ $$status"; failed=$$((failed+1)); fi; \
+	done; \
+	if [ $$failed -eq 0 ]; then echo "All services healthy"; else echo "$$failed service(s) unhealthy"; exit 1; fi
+
 lint:
 	@echo "Linting all projects with ruff..."
-	uvx ruff check $(PROJECTS)
+	@uvx ruff check $(PROJECTS)
 
 tools-format:
-	#echo "Use black to format python files"
-	for project in $(PROJECTS); do \
-		echo "Formatting project $$project..."; \
-		cd $$project && uv run black . && cd ..; \
-	done
+	@echo "Formatting all projects with ruff format..."
+	@uvx ruff format $(PROJECTS)
 
 compose-up:
 	@echo "Bringing up observability, db, kafka, ai-tools, ai, then apps (in that order)..."

--- a/customer/pyproject.toml
+++ b/customer/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ruff",
-    "black",
     "pyright",
+    "pytest>=8",
 ]
 
 [tool.uv.sources]

--- a/customer/tests/test_smoke.py
+++ b/customer/tests/test_smoke.py
@@ -1,0 +1,32 @@
+"""Smoke tests for customer service — verify producer initializes and config loads."""
+
+from confluent_kafka import Producer
+from customer.customer_producer import delivery_report, producer
+
+# All imports are at module level: a collection-time ImportError is more diagnostic
+# than a runtime ImportError buried inside a test function.
+# _FakeMsg provides the minimum confluent_kafka Message interface (topic, partition)
+# needed by delivery_report. The stub values are not asserted — the tests only verify
+# that delivery_report does not raise on either code path.
+# Note: _FakeMsg is intentionally duplicated across both producer service test files — both services
+# share the same confluent_kafka Producer interface; there is no shared test infrastructure.
+
+
+class _FakeMsg:
+    def topic(self):
+        return "test-topic"  # arbitrary stub value
+
+    def partition(self):
+        return 0  # arbitrary stub — not a real partition assertion
+
+
+def test_producer_is_initialized():
+    assert isinstance(producer, Producer)
+
+
+def test_delivery_report_handles_error():
+    delivery_report(Exception("simulated failure"), _FakeMsg())  # must not raise
+
+
+def test_delivery_report_handles_success():
+    delivery_report(None, _FakeMsg())  # must not raise

--- a/order/pyproject.toml
+++ b/order/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ruff",
-    "black",
     "pyright",
+    "pytest>=8",
 ]
 
 [tool.uv.sources]

--- a/order/tests/conftest.py
+++ b/order/tests/conftest.py
@@ -1,0 +1,13 @@
+"""conftest.py for order/tests — sets DATABASE_URL before any test module imports."""
+
+import os
+
+# Use SQLite in-memory so Flask smoke tests run without a PostgreSQL instance.
+# If DATABASE_URL is already set in the environment (e.g. overridden externally), that value is used instead.
+# Note: SQLite may not catch PostgreSQL-specific constraints (FK cascades, custom column types).
+# These tests verify the app starts and the /health endpoint responds — not schema migration fidelity.
+# Scope: this conftest.py applies to all files under order/tests/. Future test files in this
+# directory will inherit DATABASE_URL=sqlite:///:memory: unless they reassign os.environ["DATABASE_URL"] directly.
+# Timing: pytest loads conftest.py before importing test modules in this directory, so DATABASE_URL
+# is set before any module-level code in test files here runs — including module-level model imports.
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")

--- a/order/tests/test_smoke.py
+++ b/order/tests/test_smoke.py
@@ -1,0 +1,23 @@
+"""Smoke tests for order service — verify Flask app starts and health endpoint responds."""
+
+import pytest
+
+
+@pytest.fixture
+def app():
+    from order import create_app
+
+    return create_app()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_health_endpoint(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None, f"Expected JSON response, got Content-Type: {response.content_type}"
+    assert data["status"] == "healthy"

--- a/ordercheck/pyproject.toml
+++ b/ordercheck/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ruff",
-    "black",
     "pyright",
+    "pytest>=8",
 ]
 
 [tool.uv.sources]

--- a/ordercheck/tests/test_smoke.py
+++ b/ordercheck/tests/test_smoke.py
@@ -1,0 +1,25 @@
+"""Smoke tests for ordercheck service — verify consumer initializes and config loads."""
+
+from urllib.parse import urlparse
+
+from confluent_kafka import Consumer
+from ordercheck.ordercheck_consumer import API_URL, consumer
+
+# All imports are at module level: a collection-time ImportError is more diagnostic
+# than a runtime ImportError buried inside a test function.
+# Note: importing `consumer` triggers consumer.subscribe(["orders"]) at module level.
+# confluent_kafka.Consumer.subscribe() is lazy — no Kafka connection until poll().
+#
+# Scope limitation: consumer group ID, bootstrap servers, topic assignment, and ERROR_RATE
+# validity cannot be verified without a running Kafka broker. These tests confirm the module
+# loads correctly and the API URL is well-formed, not that the service is fully configured.
+
+
+def test_consumer_is_initialized():
+    assert isinstance(consumer, Consumer)
+
+
+def test_api_url_targets_orders_endpoint():
+    parsed = urlparse(API_URL)
+    assert parsed.scheme in ("http", "https")
+    assert parsed.path == "/orders"

--- a/ordermanagement/pyproject.toml
+++ b/ordermanagement/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ruff",
-    "black",
     "pyright",
+    "pytest>=8",
 ]
 
 [tool.uv.sources]

--- a/ordermanagement/tests/test_smoke.py
+++ b/ordermanagement/tests/test_smoke.py
@@ -1,0 +1,39 @@
+"""Smoke tests for ordermanagement service — verify module imports and URL constants are correct."""
+
+# The package and module share the same name (ordermanagement.ordermanagement) — this is
+# a design choice in the original service structure, not a typo.
+#
+# Scope limitation: INTERVAL_SECONDS validity, ERROR_RATE range, and the worker loop behaviour
+# cannot be verified without running Order and Stock APIs. These tests confirm the module
+# loads correctly and the URL constants are well-formed, not that the service is fully configured.
+
+from urllib.parse import urlparse
+
+from ordermanagement.ordermanagement import (
+    API_URL_ORDERS_REGISTERED,
+    API_URL_ORDERS_UPDATE,
+    API_URL_STOCKS_DECREASE,
+    HEADERS_JSON,
+)
+
+
+def test_api_url_registered_endpoint():
+    parsed = urlparse(API_URL_ORDERS_REGISTERED)
+    assert parsed.scheme in ("http", "https")
+    assert parsed.path == "/orders/status/registered"  # exact path — base host comes from API_URL_ORDERS env var
+
+
+def test_api_url_orders_update_endpoint():
+    parsed = urlparse(API_URL_ORDERS_UPDATE)
+    assert parsed.scheme in ("http", "https")
+    assert parsed.path == "/orders"  # exact path — base host comes from API_URL_ORDERS env var
+
+
+def test_api_url_stocks_decrease_endpoint():
+    parsed = urlparse(API_URL_STOCKS_DECREASE)
+    assert parsed.scheme in ("http", "https")
+    assert parsed.path == "/stocks/decrease"  # exact path — base host comes from API_URL_STOCKS env var
+
+
+def test_headers_json():
+    assert HEADERS_JSON == {"Content-Type": "application/json"}

--- a/stock/pyproject.toml
+++ b/stock/pyproject.toml
@@ -18,8 +18,8 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ruff",
-    "black",
     "pyright",
+    "pytest>=8",
 ]
 
 [tool.uv.sources]

--- a/stock/tests/conftest.py
+++ b/stock/tests/conftest.py
@@ -1,0 +1,13 @@
+"""conftest.py for stock/tests — sets DATABASE_URL before any test module imports."""
+
+import os
+
+# Use SQLite in-memory so Flask smoke tests run without a PostgreSQL instance.
+# If DATABASE_URL is already set in the environment (e.g. overridden externally), that value is used instead.
+# Note: SQLite may not catch PostgreSQL-specific constraints (FK cascades, custom column types).
+# These tests verify the app starts and the /health endpoint responds — not schema migration fidelity.
+# Scope: this conftest.py applies to all files under stock/tests/. Future test files in this
+# directory will inherit DATABASE_URL=sqlite:///:memory: unless they reassign os.environ["DATABASE_URL"] directly.
+# Timing: pytest loads conftest.py before importing test modules in this directory, so DATABASE_URL
+# is set before any module-level code in test files here runs — including module-level model imports.
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")

--- a/stock/tests/test_smoke.py
+++ b/stock/tests/test_smoke.py
@@ -1,0 +1,23 @@
+"""Smoke tests for stock service — verify Flask app starts and health endpoint responds."""
+
+import pytest
+
+
+@pytest.fixture
+def app():
+    from stock import create_app
+
+    return create_app()
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+def test_health_endpoint(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data is not None, f"Expected JSON response, got Content-Type: {response.content_type}"
+    assert data["status"] == "healthy"

--- a/supplier/pyproject.toml
+++ b/supplier/pyproject.toml
@@ -15,8 +15,8 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ruff",
-    "black",
     "pyright",
+    "pytest>=8",
 ]
 
 [tool.uv.sources]

--- a/supplier/tests/test_smoke.py
+++ b/supplier/tests/test_smoke.py
@@ -1,0 +1,32 @@
+"""Smoke tests for supplier service — verify producer initializes and config loads."""
+
+from confluent_kafka import Producer
+from supplier.supplier_producer import delivery_report, producer
+
+# All imports are at module level: a collection-time ImportError is more diagnostic
+# than a runtime ImportError buried inside a test function.
+# _FakeMsg provides the minimum confluent_kafka Message interface (topic, partition)
+# needed by delivery_report. The stub values are not asserted — the tests only verify
+# that delivery_report does not raise on either code path.
+# Note: _FakeMsg is intentionally duplicated across both producer service test files — both services
+# share the same confluent_kafka Producer interface; there is no shared test infrastructure.
+
+
+class _FakeMsg:
+    def topic(self):
+        return "test-topic"  # arbitrary stub value
+
+    def partition(self):
+        return 0  # arbitrary stub — not a real partition assertion
+
+
+def test_producer_is_initialized():
+    assert isinstance(producer, Producer)
+
+
+def test_delivery_report_handles_error():
+    delivery_report(Exception("simulated failure"), _FakeMsg())  # must not raise
+
+
+def test_delivery_report_handles_success():
+    delivery_report(None, _FakeMsg())  # must not raise

--- a/suppliercheck/pyproject.toml
+++ b/suppliercheck/pyproject.toml
@@ -15,6 +15,6 @@ dependencies = [
 [dependency-groups]
 dev = [
     "ruff",
-    "black",
     "pyright",
+    "pytest>=8",
 ]

--- a/suppliercheck/tests/test_smoke.py
+++ b/suppliercheck/tests/test_smoke.py
@@ -1,0 +1,25 @@
+"""Smoke tests for suppliercheck service — verify consumer initializes and config loads."""
+
+from urllib.parse import urlparse
+
+from confluent_kafka import Consumer
+from suppliercheck.suppliercheck_consumer import API_URL, consumer
+
+# All imports are at module level: a collection-time ImportError is more diagnostic
+# than a runtime ImportError buried inside a test function.
+# Note: importing `consumer` triggers consumer.subscribe(["stocks"]) at module level.
+# confluent_kafka.Consumer.subscribe() is lazy — no Kafka connection until poll().
+#
+# Scope limitation: consumer group ID, bootstrap servers, topic assignment, and ERROR_RATE
+# validity cannot be verified without a running Kafka broker. These tests confirm the module
+# loads correctly and the API URL is well-formed, not that the service is fully configured.
+
+
+def test_consumer_is_initialized():
+    assert isinstance(consumer, Consumer)
+
+
+def test_api_url_targets_stocks_endpoint():
+    parsed = urlparse(API_URL)
+    assert parsed.scheme in ("http", "https")
+    assert parsed.path == "/stocks"


### PR DESCRIPTION
## Summary

- Add pytest smoke tests for all 7 KEEPER services: `customer`, `order`, `ordercheck`, `ordermanagement`, `stock`, `supplier`, `suppliercheck`
- Add `order/tests/conftest.py` and `stock/tests/conftest.py`: set `DATABASE_URL=sqlite:///:memory:` before Flask app import so Flask smoke tests run without a PostgreSQL instance
- Add `make test-lint`, `make test-unit`, `make test-integration`, and `make test` targets to `Makefile`; `HEALTHCHECK_SERVICES` scopes integration checks to Flask REST APIs only (`order`, `stock`) to avoid false failures on Kafka services without container healthchecks
- Remove `black` from dev deps (embedded in ruff); use `uvx ruff format` in `tools-format`; no version pins on dev tools except `pytest>=8` lower bound
- Update `CLAUDE.md` with test target documentation and Makefile variable scopes

Closes #17, closes #18.

## Test plan

- [x] `make test-lint` — ruff check on all 7 KEEPER services → clean
- [x] `make test-unit` — 16 smoke tests across 7 services → all pass (no Docker required)
- [x] `make test-integration` — skips gracefully when stack not running
- [x] Squashed to a single commit on the branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)