### PR TITLE
fix(lib-ai): replace Python 2 except syntax with Python 3 tuple form

### DIFF
--- a/lib-ai/lib_ai/llm_utils.py
+++ b/lib-ai/lib_ai/llm_utils.py
@@ -22,7 +22,7 @@ def extract_text_from_response(response: object) -> str:
             content = response.content
             if content is not None:
                 return str(content)
-    except AttributeError, Exception:
+    except (AttributeError, Exception):
         pass
 
     # Try text attribute (alternative)
@@ -31,7 +31,7 @@ def extract_text_from_response(response: object) -> str:
             text = response.text
             if text is not None:
                 return str(text)
-    except AttributeError, Exception:
+    except (AttributeError, Exception):
         pass
 
     # Fallback to string representation


### PR DESCRIPTION
## Summary

- Fixes SyntaxError in `lib-ai/lib_ai/llm_utils.py` caused by Python 2 exception syntax (`except AttributeError, Exception:`)
- Replaces both occurrences (lines 25 and 34) with Python 3 tuple form: `except (AttributeError, Exception):`
- All agent services importing `lib_ai.llm_utils` were crashing silently on startup

## Test plan

- [x] `uv run python -c "from lib_ai.llm_utils import extract_text_from_response"` → OK, no SyntaxError
- [ ] Smoke test agent services importing lib-ai (`agent-traduction`, `benchmark`)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)