### PR TITLE
chore: code quality findings L1-L3, L5-L8 from adversarial review

### DIFF
--- a/lib-ai/lib_ai/agent_models.py
+++ b/lib-ai/lib_ai/agent_models.py
@@ -4,7 +4,7 @@ Shared Pydantic models for agent communication
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Optional
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -46,7 +46,7 @@ class AgentResponse(BaseModel):
     confidence: float = Field(default=0.5, ge=0.0, le=1.0, description="Confidence score (0-1)")
     grafana_links: list[str] = Field(default_factory=list, description="Links to Grafana dashboards/queries")
     timestamp: datetime = Field(default_factory=datetime.now, description="Response timestamp")
-    error: Optional[str] = Field(default=None, description="Error message if analysis failed")
+    error: str | None = Field(default=None, description="Error message if analysis failed")
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/lib-ai/lib_ai/llm_config.py
+++ b/lib-ai/lib_ai/llm_config.py
@@ -31,7 +31,7 @@ def load_model_params_config() -> dict:
 
     # Try multiple paths (development, docker, installed package)
     possible_paths = [
-        Path(__file__).parent.parent.parent / "config" / "ai" / "model-params.yml",  # From common-ai in workspace
+        Path(__file__).parent.parent.parent / "config" / "ai" / "model-params.yml",  # From lib-ai in workspace
         Path("/app/config/ai/model-params.yml"),  # Docker container
         Path.cwd() / "config" / "ai" / "model-params.yml",  # Current directory
     ]
@@ -113,21 +113,6 @@ class SafeChatOpenAI(ChatOpenAI):
                 raise
             else:
                 raise
-
-    def _convert_input_to_messages(self, input: Any) -> list[dict]:
-        """Convert LangChain input format to OpenAI API format."""
-        if isinstance(input, str):
-            return [{"role": "user", "content": input}]
-        elif isinstance(input, list):
-            messages = []
-            for msg in input:
-                if hasattr(msg, "type") and hasattr(msg, "content"):
-                    messages.append({"role": msg.type, "content": msg.content})
-                elif isinstance(msg, dict):
-                    messages.append(msg)
-            return messages
-        else:
-            return [{"role": "user", "content": str(input)}]
 
 
 def get_llm(

--- a/lib-ai/lib_ai/mcp_client.py
+++ b/lib-ai/lib_ai/mcp_client.py
@@ -4,6 +4,7 @@ Provides unified interface to query Loki, Mimir, and Tempo via the Grafana MCP s
 """
 
 import asyncio
+import json
 import logging
 from contextlib import AsyncExitStack
 from datetime import datetime, timedelta
@@ -127,8 +128,6 @@ class MCPGrafanaClient:
 
             # Parse response to extract UIDs
             if result.content:
-                import json
-
                 for content_item in result.content:
                     if hasattr(content_item, "text"):
                         datasources = json.loads(content_item.text)
@@ -234,8 +233,6 @@ class MCPGrafanaClient:
 
             # Extract logs from MCP response
             if result.content:
-                import json
-
                 for content_item in result.content:
                     if hasattr(content_item, "text"):
                         logs_data = json.loads(content_item.text)
@@ -300,8 +297,6 @@ class MCPGrafanaClient:
 
             # Extract metrics from MCP response
             if result.content:
-                import json
-
                 for content_item in result.content:
                     if hasattr(content_item, "text"):
                         metrics_data = json.loads(content_item.text)
@@ -387,8 +382,6 @@ class MCPGrafanaClient:
 
             # Extract traces from MCP response
             if result.content:
-                import json
-
                 for content_item in result.content:
                     if hasattr(content_item, "text"):
                         traces_data = json.loads(content_item.text)
@@ -435,8 +428,6 @@ class MCPGrafanaClient:
         Returns:
             Parsed JSON data or empty dict/list
         """
-        import json
-
         if result.content:
             for content_item in result.content:
                 if hasattr(content_item, "text"):

--- a/lib-models/lib_models/models.py
+++ b/lib-models/lib_models/models.py
@@ -1,4 +1,3 @@
-# Fichier: src/common/models.py
 from datetime import datetime
 from enum import Enum
 

--- a/ms-ordercheck/pyproject.toml
+++ b/ms-ordercheck/pyproject.toml
@@ -5,7 +5,6 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
-    "lib-models",
     "confluent-kafka>=2.12.2",
     "opentelemetry-distro>=0.59b0",
     "opentelemetry-exporter-otlp>=1.38.0",
@@ -20,5 +19,3 @@ dev = [
     "pytest>=8",
 ]
 
-[tool.uv.sources]
-lib-models = { path = "../lib-models", editable = true }

--- a/ms-ordermanagement/ordermanagement/ordermanagement.py
+++ b/ms-ordermanagement/ordermanagement/ordermanagement.py
@@ -31,7 +31,7 @@ def fetch_registered_orders():
         orders = response.json()
         return orders
     except requests.RequestException as e:
-        logger.error(f"Failed to fetch orders: {e}")
+        logger.error("Failed to fetch orders: %s", e)
         return []
 
 
@@ -94,7 +94,7 @@ def process_registered_order():
             update_order_status(order["id"], OrderStatus.READY)
             logger.info("Order status updated to READY for order: %s", order)
         except Exception as e:
-            logger.error(f"Failed to process order {order['id']}: {e}")
+            logger.error("Failed to process order %s: %s", order["id"], e)
             # Attempt to mark the order as BLOCKED, but don't let a failed
             # status update crash the whole worker. Log failures and continue.
             try:


### PR DESCRIPTION
## Summary

Low severity code quality findings from adversarial review of ms-* and lib-* services.

- **L1** — `lib-models/models.py`: removed stale path comment (`src/common/models.py` no longer accurate)
- **L2** — `ms-ordercheck/pyproject.toml`: removed unused `lib-models` dependency (consumer uses raw JSON dicts, never imports from lib_models — already noted as tech debt in CLAUDE.md)
- **L3** — `ms-ordermanagement/ordermanagement.py`: harmonized logging to `%s` style (f-strings → lazy evaluation)
- **L5** — `lib-ai/llm_config.py`: updated stale comment `common-ai` → `lib-ai`
- **L6** — `lib-ai/llm_config.py`: removed dead method `SafeChatOpenAI._convert_input_to_messages()` (defined, never called)
- **L7** — `lib-ai/mcp_client.py`: moved `import json` from 5 function bodies to module level
- **L8** — `lib-ai/agent_models.py`: replaced `Optional[str]` with `str | None` (Python 3.10+ union syntax, consistent with rest of codebase)

## Test plan

- [x] `ruff check` passes on all 6 files
- [ ] `uv run pytest` on ms-ordercheck (verify no import of lib_models in tests)

Partial #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)