### PR TITLE
fix(infra): separate PostgreSQL databases and externalize password to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,9 @@ IMG_PYTHON_BASE=python:3.14-slim
 # Grafana Service Account Token
 GRAFANA_SERVICE_ACCOUNT_TOKEN=replace_with_your_token
 
+# PostgreSQL password (used by docker-compose-db.yml and docker-compose-apps.yml)
+POSTGRES_PASSWORD=yourpassword
+
 # Docker image variables used by docker-compose files. Copy to .env to override.
 # Format: DOCKER_IMG_<SERVICE>=<image:tag>
 DOCKER_IMG_GRAFANA=grafana/grafana:12.2

--- a/docker-compose/docker-compose-apps.yml
+++ b/docker-compose/docker-compose-apps.yml
@@ -54,7 +54,7 @@ services:
     environment:
       <<: *common-apps-env
       OTEL_SERVICE_NAME: ms-order
-      DATABASE_URL: postgresql://postgres:yourpassword@postgres:5432/mydatabase
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-yourpassword}@postgres:5432/order_db
     restart: unless-stopped
     networks:
       - otel-network
@@ -70,7 +70,7 @@ services:
     environment:
       <<: *common-apps-env
       OTEL_SERVICE_NAME: ms-stock
-      DATABASE_URL: postgresql://postgres:yourpassword@postgres:5432/mydatabase
+      DATABASE_URL: postgresql://postgres:${POSTGRES_PASSWORD:-yourpassword}@postgres:5432/stock_db
     restart: unless-stopped
     networks:
       - otel-network

--- a/docker-compose/docker-compose-db.yml
+++ b/docker-compose/docker-compose-db.yml
@@ -4,10 +4,11 @@ services:
     container_name: postgres
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: yourpassword
-      POSTGRES_DB: mydatabase
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-yourpassword}
+      POSTGRES_DB: postgres
     volumes:
       - postgres-data:/var/lib/postgresql
+      - ./init-db.sql:/docker-entrypoint-initdb.d/init-db.sql:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s

--- a/docker-compose/init-db.sql
+++ b/docker-compose/init-db.sql
@@ -1,0 +1,4 @@
+-- PostgreSQL initialization script
+-- Creates isolated databases for ms-order and ms-stock (microservice DB isolation pattern)
+CREATE DATABASE order_db;
+CREATE DATABASE stock_db;


### PR DESCRIPTION
## Summary

- **#39** — Create isolated databases `order_db` and `stock_db` via a new init script (`docker-compose/init-db.sql`). Update `DATABASE_URL` for `ms-order` → `order_db` and `ms-stock` → `stock_db`. Microservice DB isolation pattern — no cross-service queries exist.
- **#40** — Replace hardcoded `yourpassword` in `docker-compose-db.yml` and `docker-compose-apps.yml` with `${POSTGRES_PASSWORD:-yourpassword}`. Add `POSTGRES_PASSWORD=yourpassword` to `.env.example`.

## Files changed

- `docker-compose/init-db.sql` ← new init script
- `docker-compose/docker-compose-db.yml`
- `docker-compose/docker-compose-apps.yml`
- `.env.example`

## Test plan

- [ ] `docker compose up postgres` → both `order_db` and `stock_db` created on first start
- [ ] `ms-order` connects to `order_db`, `ms-stock` connects to `stock_db`
- [ ] Setting `POSTGRES_PASSWORD=mypass` in `.env` propagates correctly

⚠️ **Breaking change for existing volumes** — existing `postgres-data` volume uses `mydatabase`. Run `docker compose down -v` to reset before bringing stack up.

Closes #39
Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)