### PR TITLE
test(ms-order,ms-stock): CRUD tests with SQLite temp file (0 mock)

### DIFF
--- a/ms-order/tests/conftest.py
+++ b/ms-order/tests/conftest.py
@@ -1,13 +1,31 @@
-"""conftest.py for order/tests — sets DATABASE_URL before any test module imports."""
+"""conftest.py for order/tests — sets DATABASE_URL before any test module imports.
+
+Uses a named temporary SQLite file so that Flask-SQLAlchemy's internal engine
+(used by db.create_all) and the raw SQLAlchemy engine (SessionLocal in routes)
+both connect to the same physical database. sqlite:///:memory: creates a separate
+DB per engine instance and is not suitable for this dual-engine setup.
+
+ERROR_RATE=0 eliminates random simulated errors during CRUD tests.
+"""
 
 import os
+import tempfile
 
-# Use SQLite in-memory so Flask smoke tests run without a PostgreSQL instance.
-# If DATABASE_URL is already set in the environment (e.g. overridden externally), that value is used instead.
-# Note: SQLite may not catch PostgreSQL-specific constraints (FK cascades, custom column types).
-# These tests verify the app starts and the /health endpoint responds — not schema migration fidelity.
-# Scope: this conftest.py applies to all files under order/tests/. Future test files in this
-# directory will inherit DATABASE_URL=sqlite:///:memory: unless they reassign os.environ["DATABASE_URL"] directly.
-# Timing: pytest loads conftest.py before importing test modules in this directory, so DATABASE_URL
-# is set before any module-level code in test files here runs — including module-level model imports.
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+import pytest
+
+# Create a temp SQLite file for the test session. setdefault means an externally-set
+# DATABASE_URL (e.g. real PostgreSQL in CI) takes precedence.
+_db_fd, _db_path = tempfile.mkstemp(suffix="_order_test.db")
+os.close(_db_fd)
+os.environ.setdefault("DATABASE_URL", f"sqlite:///{_db_path}")
+os.environ.setdefault("ERROR_RATE", "0")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_test_db():
+    """Remove the SQLite test file after the entire test session."""
+    yield
+    try:
+        os.unlink(_db_path)
+    except OSError:
+        pass

--- a/ms-order/tests/test_crud.py
+++ b/ms-order/tests/test_crud.py
@@ -1,0 +1,131 @@
+"""CRUD tests for ms-order Flask routes using SQLite in-memory database.
+
+Fixtures: app (session-scoped, shared across all tests in this file),
+client (function-scoped), clean_orders (autouse — deletes all rows before each test).
+
+The conftest.py sets DATABASE_URL to a named shared-memory SQLite URI before any
+module imports, ensuring both Flask-SQLAlchemy (db.create_all) and raw SessionLocal
+(used in routes) connect to the same in-memory database.
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def app():
+    from order import create_app
+
+    return create_app()
+
+
+@pytest.fixture
+def client(app):
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def clean_orders(app):
+    """Delete all orders before each test for isolation."""
+    with app.app_context():
+        from order.database import db
+        from order.models import Order
+
+        db.session.query(Order).delete()
+        db.session.commit()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# POST /orders
+# ---------------------------------------------------------------------------
+
+
+def test_create_order_returns_201(client):
+    response = client.post("/orders/", json={"wood_type": "oak", "quantity": 5})
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["wood_type"] == "oak"
+    assert data["quantity"] == 5
+    assert "id" in data
+
+
+def test_create_order_missing_body_returns_400(client):
+    # Empty body with JSON content-type: Flask's request.json returns None → route returns 400.
+    # The response body may be empty (no JSON payload) depending on how Flask handles the bad request.
+    response = client.post("/orders/", data="", content_type="application/json")
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /orders
+# ---------------------------------------------------------------------------
+
+
+def test_get_orders_returns_200_and_list(client):
+    client.post("/orders/", json={"wood_type": "oak", "quantity": 3})
+    response = client.get("/orders/")
+    assert response.status_code == 200
+    assert isinstance(response.get_json(), list)
+    assert len(response.get_json()) == 1
+
+
+def test_get_orders_invalid_skip_returns_400(client):
+    response = client.get("/orders/?skip=abc")
+    assert response.status_code == 400
+    assert "skip and limit must be integers" in response.get_json()["error"]
+
+
+def test_get_orders_invalid_limit_returns_400(client):
+    response = client.get("/orders/?limit=xyz")
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /orders/status/<status>
+# ---------------------------------------------------------------------------
+
+
+def test_get_orders_by_status_registered_returns_200(client):
+    client.post("/orders/", json={"wood_type": "maple", "quantity": 2})
+    response = client.get("/orders/status/registered")
+    assert response.status_code == 200
+    assert isinstance(response.get_json(), list)
+
+
+def test_get_orders_by_invalid_status_returns_400(client):
+    response = client.get("/orders/status/nonexistent")
+    assert response.status_code == 400
+    assert "Invalid status" in response.get_json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# PUT /orders/<id>
+# ---------------------------------------------------------------------------
+
+
+def test_update_order_status_returns_200(client):
+    create_resp = client.post("/orders/", json={"wood_type": "birch", "quantity": 1})
+    order_id = create_resp.get_json()["id"]
+    response = client.put(f"/orders/{order_id}", json={"order_status": "shipped"})
+    assert response.status_code == 200
+    assert response.get_json()["order_status"] == "shipped"
+
+
+def test_update_order_status_invalid_status_returns_400(client):
+    create_resp = client.post("/orders/", json={"wood_type": "pine", "quantity": 1})
+    order_id = create_resp.get_json()["id"]
+    response = client.put(f"/orders/{order_id}", json={"order_status": "invalid_status"})
+    assert response.status_code == 400
+
+
+def test_update_order_status_missing_body_returns_400(client):
+    create_resp = client.post("/orders/", json={"wood_type": "elm", "quantity": 1})
+    order_id = create_resp.get_json()["id"]
+    response = client.put(f"/orders/{order_id}", data="", content_type="application/json")
+    assert response.status_code == 400
+
+
+def test_update_order_status_not_found_returns_404(client):
+    response = client.put("/orders/99999", json={"order_status": "shipped"})
+    assert response.status_code == 404

--- a/ms-stock/tests/conftest.py
+++ b/ms-stock/tests/conftest.py
@@ -1,13 +1,31 @@
-"""conftest.py for stock/tests — sets DATABASE_URL before any test module imports."""
+"""conftest.py for stock/tests — sets DATABASE_URL before any test module imports.
+
+Uses a named temporary SQLite file so that Flask-SQLAlchemy's internal engine
+(used by db.create_all) and the raw SQLAlchemy engine (SessionLocal in routes)
+both connect to the same physical database. sqlite:///:memory: creates a separate
+DB per engine instance and is not suitable for this dual-engine setup.
+
+ERROR_RATE=0 eliminates random simulated errors during CRUD tests.
+"""
 
 import os
+import tempfile
 
-# Use SQLite in-memory so Flask smoke tests run without a PostgreSQL instance.
-# If DATABASE_URL is already set in the environment (e.g. overridden externally), that value is used instead.
-# Note: SQLite may not catch PostgreSQL-specific constraints (FK cascades, custom column types).
-# These tests verify the app starts and the /health endpoint responds — not schema migration fidelity.
-# Scope: this conftest.py applies to all files under stock/tests/. Future test files in this
-# directory will inherit DATABASE_URL=sqlite:///:memory: unless they reassign os.environ["DATABASE_URL"] directly.
-# Timing: pytest loads conftest.py before importing test modules in this directory, so DATABASE_URL
-# is set before any module-level code in test files here runs — including module-level model imports.
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+import pytest
+
+# Create a temp SQLite file for the test session. setdefault means an externally-set
+# DATABASE_URL (e.g. real PostgreSQL in CI) takes precedence.
+_db_fd, _db_path = tempfile.mkstemp(suffix="_stock_test.db")
+os.close(_db_fd)
+os.environ.setdefault("DATABASE_URL", f"sqlite:///{_db_path}")
+os.environ.setdefault("ERROR_RATE", "0")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cleanup_test_db():
+    """Remove the SQLite test file after the entire test session."""
+    yield
+    try:
+        os.unlink(_db_path)
+    except OSError:
+        pass

--- a/ms-stock/tests/test_crud.py
+++ b/ms-stock/tests/test_crud.py
@@ -1,0 +1,134 @@
+"""CRUD tests for ms-stock Flask routes using SQLite in-memory database.
+
+Fixtures: app (session-scoped, shared across all tests in this file),
+client (function-scoped), clean_stocks (autouse — deletes all rows before each test).
+
+The conftest.py sets DATABASE_URL to a temp SQLite file before any module imports,
+ensuring both Flask-SQLAlchemy (db.create_all) and raw SessionLocal (used in routes)
+connect to the same physical database.
+"""
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def app():
+    from stock import create_app
+
+    return create_app()
+
+
+@pytest.fixture
+def client(app):
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture(autouse=True)
+def clean_stocks(app):
+    """Delete all stocks before each test for isolation."""
+    with app.app_context():
+        from stock.database import db
+        from stock.models import Stock
+
+        db.session.query(Stock).delete()
+        db.session.commit()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# POST /stocks
+# ---------------------------------------------------------------------------
+
+
+def test_create_stock_returns_201(client):
+    response = client.post("/stocks/", json={"wood_type": "oak", "quantity": 50})
+    assert response.status_code == 201
+    data = response.get_json()
+    assert data["wood_type"] == "oak"
+    assert data["quantity"] == 50
+    # Stock uses wood_type as PK — no separate id field
+
+
+def test_create_stock_missing_body_returns_400(client):
+    response = client.post("/stocks/", data="", content_type="application/json")
+    assert response.status_code == 400
+
+
+def test_create_stock_same_wood_type_accumulates(client):
+    """Creating stock with same wood type should accumulate quantity."""
+    client.post("/stocks/", json={"wood_type": "maple", "quantity": 10})
+    client.post("/stocks/", json={"wood_type": "maple", "quantity": 5})
+    response = client.get("/stocks/maple")
+    assert response.status_code == 200
+    assert response.get_json()["quantity"] == 15
+
+
+# ---------------------------------------------------------------------------
+# GET /stocks
+# ---------------------------------------------------------------------------
+
+
+def test_get_stocks_returns_200_and_list(client):
+    client.post("/stocks/", json={"wood_type": "birch", "quantity": 20})
+    response = client.get("/stocks/")
+    assert response.status_code == 200
+    assert isinstance(response.get_json(), list)
+    assert len(response.get_json()) == 1
+
+
+def test_get_stocks_invalid_skip_returns_400(client):
+    response = client.get("/stocks/?skip=abc")
+    assert response.status_code == 400
+    assert "skip and limit must be integers" in response.get_json()["error"]
+
+
+def test_get_stocks_invalid_limit_returns_400(client):
+    response = client.get("/stocks/?limit=xyz")
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /stocks/<wood_type>
+# ---------------------------------------------------------------------------
+
+
+def test_get_stock_by_wood_type_returns_200(client):
+    client.post("/stocks/", json={"wood_type": "pine", "quantity": 30})
+    response = client.get("/stocks/pine")
+    assert response.status_code == 200
+    assert response.get_json()["wood_type"] == "pine"
+
+
+def test_get_stock_by_wood_type_not_found_returns_404(client):
+    response = client.get("/stocks/elm")
+    assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# POST /stocks/decrease
+# ---------------------------------------------------------------------------
+
+
+def test_decrease_stock_returns_200(client):
+    client.post("/stocks/", json={"wood_type": "oak", "quantity": 100})
+    response = client.post("/stocks/decrease", json={"wood_type": "oak", "quantity": 10})
+    assert response.status_code == 200
+    assert response.get_json()["quantity"] == 90
+
+
+def test_decrease_stock_insufficient_returns_400(client):
+    client.post("/stocks/", json={"wood_type": "maple", "quantity": 5})
+    response = client.post("/stocks/decrease", json={"wood_type": "maple", "quantity": 100})
+    assert response.status_code == 400
+    assert "Insufficient" in response.get_json()["error"]
+
+
+def test_decrease_stock_not_found_returns_404(client):
+    response = client.post("/stocks/decrease", json={"wood_type": "birch", "quantity": 1})
+    assert response.status_code == 404
+
+
+def test_decrease_stock_missing_body_returns_400(client):
+    response = client.post("/stocks/decrease", data="", content_type="application/json")
+    assert response.status_code == 400


### PR DESCRIPTION
## Summary

Real CRUD tests for both Flask REST APIs — zero mocks, no Docker, no PostgreSQL required.

### ms-order (11 new tests + conftest update)
- `POST /orders/` → 201 + body fields, missing body → 400
- `GET /orders/` → 200 + list, `skip=abc` → 400, `limit=xyz` → 400
- `GET /orders/status/registered` → 200 + list, invalid status → 400
- `PUT /orders/<id>` → 200 + updated status, invalid status → 400, missing body → 400, not found → 404

### ms-stock (12 new tests + conftest update)
- `POST /stocks/` → 201 + body, missing body → 400, same wood_type accumulates quantity
- `GET /stocks/` → 200 + list, `skip=abc` → 400, `limit=xyz` → 400
- `GET /stocks/<wood_type>` → 200 + body, not found → 404
- `POST /stocks/decrease` → 200 + decremented qty, insufficient → 400, not found → 404, missing body → 400

**SQLite strategy:** both `conftest.py` files updated to use a named temp file via `tempfile.mkstemp`. This ensures Flask-SQLAlchemy's internal engine (`db.create_all`) and the raw `SessionLocal` used in routes both connect to the same physical database. `sqlite:///:memory:` was not usable because it creates isolated in-memory DBs per engine instance.

`ERROR_RATE=0` set in conftest to eliminate simulated errors during tests.

## Test plan

- [x] `uv run pytest tests/ -v` — ms-order: 12/12 ✅
- [x] `uv run pytest tests/ -v` — ms-stock: 13/13 ✅
- [x] `ruff check` clean on all new/modified files

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)