### PR TITLE
fix(infra): add --no-recreate to podman-compose up calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Two-layer model:
 ## Key Task Targets
 
 ```bash
-task compose-up       # Start full stack (observability → db → kafka → ai-tools → ai → apps → traefik)
+task compose-up       # Start full stack (observability → db → kafka → ai-tools → ai → apps → traefik) — idempotent: running containers are preserved; use compose-down first to apply config/image changes
 task compose-down     # Stop all services: traefik first (ingress), then apps → ai → ai-tools → kafka → db → observability
 task lint             # Ruff check across all projects (PROJECTS var — includes agents)
 task tools-format     # Ruff format across all projects (runs from repo root, applies root pyproject.toml config)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,6 +64,10 @@ tasks:
 
   compose-up:
     desc: "Start full stack: observability → db → kafka → ai-tools → ai → apps → traefik"
+    # --no-recreate: prevents podman-compose from stopping/removing containers already running in the
+    # shared Podman pod, which causes "container state improper" errors when layers start sequentially.
+    # Trade-off: if the stack is already running, config/image changes are NOT applied (containers kept as-is).
+    # To apply changes, always run: task compose-down && task compose-up
     silent: true
     cmds:
       - |


### PR DESCRIPTION
## Summary

- `podman-compose up -d` tries to recreate all containers in the shared Podman pod on each invocation
- When subsequent layers (db, kafka, ...) run, they encounter already-running containers from previous layers (observability, ...) → `container state improper` errors
- Adding `--no-recreate` prevents podman-compose from stopping/removing running containers

## Root cause

All compose files share the same Podman pod (same project = same directory). Each `up -d` call internally does a stop/remove before create. Since the stack is started layer by layer, later layers try to touch containers that are already running from earlier layers.

## Behaviour after fix

No more spurious errors during `task compose-up`. The expected workflow remains unchanged:
```
task compose-down && task compose-up   # to apply config changes
task compose-up                        # idempotent if stack already up
```

## Test plan

- [ ] `task compose-up` on a clean state — no `container state improper` errors
- [ ] `task compose-up` on a running stack — containers not recreated, no errors
- [ ] `task compose-down && task compose-up` — full restart works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)