### PR TITLE
fix(infra): remove cross-file depends_on broker from docker-compose-apps.yml

### DIFF
--- a/docker-compose/docker-compose-apps.yml
+++ b/docker-compose/docker-compose-apps.yml
@@ -22,9 +22,6 @@ services:
       OTEL_SERVICE_NAME: ms-customer
       KAFKA_BOOTSTRAP_SERVERS: broker:29092
       INTERVAL_SECONDS: 5
-    depends_on:
-      broker:
-        condition: service_healthy
     restart: unless-stopped
     networks:
       - otel-network
@@ -42,9 +39,6 @@ services:
       OTEL_SERVICE_NAME: ms-supplier
       KAFKA_BOOTSTRAP_SERVERS: broker:29092
       INTERVAL_SECONDS: 5
-    depends_on:
-      broker:
-        condition: service_healthy
     restart: unless-stopped
     networks:
       - otel-network
@@ -97,8 +91,6 @@ services:
     depends_on:
       ms-order:
         condition: service_started
-      broker:
-        condition: service_healthy
     restart: unless-stopped
     networks:
       - otel-network
@@ -119,8 +111,6 @@ services:
     depends_on:
       ms-stock:
         condition: service_started
-      broker:
-        condition: service_healthy
     restart: unless-stopped
     networks:
       - otel-network


### PR DESCRIPTION
## Summary

- `podman-compose` raises `KeyError: 'broker'` when a service has `depends_on: broker` but `broker` is defined in a different compose file (`docker-compose-kafka.yml`)
- This error surfaces with `--no-recreate` (PR #61): when containers already exist, podman-compose takes the `podman start` path and checks deps — failing on cross-file references
- Startup order is already guaranteed by the `compose-up` task sequence (`kafka` before `apps`)
- `restart: unless-stopped` handles the race condition if Kafka isn't ready at first boot

## Changes

Removed `depends_on: broker` from 4 services in `docker-compose-apps.yml`:
- `ms-customer`
- `ms-supplier`
- `ms-ordercheck` (kept `depends_on: ms-order`)
- `ms-suppliercheck` (kept `depends_on: ms-stock`)

## Test plan

- [ ] `task compose-down && task compose-up` — no `KeyError: 'broker'`
- [ ] `task compose-up` on running stack — idempotent, no errors
- [ ] All services connect to Kafka after startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)