### PR TITLE
docs(ms-brewery,ms-cellar): fix OTEL_SERVICE_NAME convention → ms-brewery, ms-cellar

### DIFF
--- a/ms-brewery/CLAUDE.md
+++ b/ms-brewery/CLAUDE.md
@@ -42,7 +42,7 @@ and serves brew data to `ms-brewmaster`.
 | Variable | Purpose |
 |----------|---------|
 | `DATABASE_URL` | PostgreSQL connection string |
-| `OTEL_SERVICE_NAME` | `brewery` |
+| `OTEL_SERVICE_NAME` | `ms-brewery` |
 | `LOG_LEVEL` | Logging verbosity |
 
 ## What I learned building this

--- a/ms-cellar/CLAUDE.md
+++ b/ms-cellar/CLAUDE.md
@@ -41,7 +41,7 @@ requested by `ms-brewmaster` when brews are fulfilled.
 | Variable | Purpose |
 |----------|---------|
 | `DATABASE_URL` | PostgreSQL connection string |
-| `OTEL_SERVICE_NAME` | `cellar` |
+| `OTEL_SERVICE_NAME` | `ms-cellar` |
 | `LOG_LEVEL` | Logging verbosity |
 
 ## What I learned building this


### PR DESCRIPTION
## Summary
- Fix \`OTEL_SERVICE_NAME\` in CLAUDE.md for \`ms-brewery\` and \`ms-cellar\`
- Align with project-wide \`ms-xxxx\` convention (was: \`brewery\`, \`cellar\`)

Part of the brewery-phase-1 OTEL naming convention alignment.

## Test plan
- [x] No code change — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)