### PR TITLE
chore(docs): update project docs for brewery domain rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,13 +15,13 @@ Two-layer model:
 
 | Service | Type | Framework |
 |---------|------|-----------|
-| `ms-customer` | Kafka producer | none |
+| `ms-brewer` | Kafka producer | none |
 | `ms-supplier` | Kafka producer | none |
-| `ms-ordercheck` | Kafka consumer | none |
-| `ms-suppliercheck` | Kafka consumer | none |
-| `ms-ordermanagement` | Background worker | none |
-| `ms-order` | REST API + DB | Flask + SQLAlchemy |
-| `ms-stock` | REST API + DB | Flask + SQLAlchemy |
+| `ms-brewcheck` | Kafka consumer | none |
+| `ms-ingredientcheck` | Kafka consumer | none |
+| `ms-brewmaster` | Background worker | none |
+| `ms-brewery` | REST API + DB | Flask + SQLAlchemy |
+| `ms-cellar` | REST API + DB | Flask + SQLAlchemy |
 | `lib-models` | Shared library | Pydantic v2 |
 | `lib-ai` | Shared AI library | LangChain + MCP |
 | `config` | Infra config files | YAML |
@@ -33,7 +33,7 @@ Two-layer model:
 
 ## Framework Convention
 
-- **Flask** for KEEPER HTTP services (`ms-order`, `ms-stock`) — synchronous, SQLAlchemy-based. No migration to FastAPI planned.
+- **Flask** for KEEPER HTTP services (`ms-brewery`, `ms-cellar`) — synchronous, SQLAlchemy-based. No migration to FastAPI planned.
 - **FastAPI** for all agent services — async, LLM-friendly.
 
 ## Tools
@@ -49,6 +49,7 @@ Two-layer model:
 ```bash
 task compose-up       # Start full stack (observability → db → kafka → ai-tools → ai → apps → traefik) — idempotent: running containers are preserved; use compose-down first to apply config/image changes
 task compose-down     # Stop all services: traefik first (ingress), then apps → ai → ai-tools → kafka → db → observability
+task compose-reset    # Full reset: down (remove volumes + built images) then up — use after image changes or DB schema changes
 task lint             # Ruff check across all projects (PROJECTS var — includes agents)
 task tools-format     # Ruff format across all projects (runs from repo root, applies root pyproject.toml config)
 task models-init      # Pull Ollama AI models (mistral, llama, qwen, etc.)
@@ -56,13 +57,13 @@ task test             # test-lint → test-unit → test-integration (sequential
 task --continue test  # Run all test phases even if one fails
 task test-lint        # Ruff check scoped to KEEPER_SERVICES only (subset of lint)
 task test-unit        # Pytest smoke tests — KEEPER_SERVICES only (7 dirs), no Docker required
-task test-integration # Container health checks (ms-order, ms-stock only) — skips if stack not running or runtime absent; unhealthy containers report failure
+task test-integration # Container health checks (ms-brewery, ms-cellar only) — skips if stack not running or runtime absent; unhealthy containers report failure
 task --list           # Show all available tasks with descriptions
 ```
 
 > **Taskfile variable scopes:** `PROJECTS` = all services (see `Taskfile.yml` for the full list), used by `task lint`.
 > `KEEPER_SERVICES` (7 dirs) = business services with runnable processes, used by `task test-lint` and `task test-unit`.
-> `HEALTHCHECK_SERVICES` (2 dirs) = `ms-order` and `ms-stock` — only Flask services with container healthchecks, used by the `test-integration` health loop.
+> `HEALTHCHECK_SERVICES` (2 dirs) = `ms-brewery` and `ms-cellar` — only Flask services with container healthchecks, used by the `test-integration` health loop.
 > Agent services (`agent-*`) and shared libs (`lib-*`) are in `PROJECTS` but not `KEEPER_SERVICES`.
 
 ## Environment Setup
@@ -86,7 +87,7 @@ Telemetry flows: logs → Loki, metrics → Mimir, traces → Tempo, UI → Graf
 ## Error Injection
 
 `ERROR_RATE` env var (0.0–1.0, default 0.1) injects random failures in Kafka producers, consumers,
-and the ordermanagement worker. The Flask REST APIs (`ms-order`, `ms-stock`) do not use `ERROR_RATE`.
+and the brewmaster worker. The Flask REST APIs (`ms-brewery`, `ms-cellar`) do not use `ERROR_RATE`.
 This is intentional — generates realistic, noisy telemetry for learning OTEL.
 
 ## Shared Libraries
@@ -98,8 +99,8 @@ This is intentional — generates realistic, noisy telemetry for learning OTEL.
 
 All services are behind **Traefik** (port 8081). Direct access:
 - Grafana: `http://localhost:3000`
-- Order API: `http://localhost:5000`
-- Stock API: `http://localhost:5001`
+- Brewery API: `http://localhost:5000`
+- Cellar API: `http://localhost:5001`
 
 Via Traefik (`http://localhost:8081`):
 - Kafka UI (AKHQ): `http://localhost:8081/akhq/`

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -337,12 +337,15 @@ task compose-up
 # Stop all services
 task compose-down
 
+# Full reset: remove volumes + built images, then restart (use after image changes or DB schema changes)
+task compose-reset
+
 # Rebuild a specific service (useful during development)
 podman-compose -f <compose-files...> up --build -d <service> || \
    docker-compose -f <compose-files...> up --build -d <service>
 
 # View logs for specific service
-podman-compose logs -f order || docker-compose logs -f order
+podman-compose logs -f ms-brewery || docker-compose logs -f ms-brewery
 
 # Complete cleanup (removes all data)
 task compose-down && podman-compose down -v || docker-compose down -v

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Note: the compose configuration is split across multiple files. Use the provided
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│  Business Application (Order & Stock Management)            │
-│  customer → kafka → ordercheck → order → postgres          │
-│  supplier → kafka → suppliercheck → stock → postgres       │
+│  Business Application (Brewery)                             │
+│  brewer   → kafka → brewcheck     → brewery → postgres     │
+│  supplier → kafka → ingredientcheck → cellar → postgres    │
 └─────────────────────────────────────────────────────────────┘
                           ↓ OTLP
 ┌─────────────────────────────────────────────────────────────┐
@@ -70,15 +70,15 @@ See [Architecture Documentation](docs/architecture.md) for detailed diagrams.
 ## 🗂️ Project Structure
 
 ```
-├── lib-models/          # Shared business models (WoodType, Order, Stock)
-├── lib-ai/              # Shared AI utilities (MCP client, LLM config, agent models)
-├── ms-customer/         # Microservice: Customer orders (Kafka producer)
-├── ms-order/            # Microservice: Order management API
-├── ms-stock/            # Microservice: Stock management API
-├── ms-supplier/         # Microservice: Supplier (Kafka producer)
-├── ms-ordercheck/       # Microservice: Order processing (Kafka consumer)
-├── ms-suppliercheck/    # Microservice: Stock updates (Kafka consumer)
-├── ms-ordermanagement/  # Microservice: Order status updates
+├── lib-models/            # Shared business models (IngredientType, BrewStatus, BrewStyle)
+├── lib-ai/                # Shared AI utilities (MCP client, LLM config, agent models)
+├── ms-brewer/             # Microservice: Brew orders (Kafka producer)
+├── ms-brewery/            # Microservice: Brewery API (Flask + PostgreSQL)
+├── ms-cellar/             # Microservice: Cellar/ingredient stock API (Flask + PostgreSQL)
+├── ms-supplier/           # Microservice: Ingredient deliveries (Kafka producer)
+├── ms-brewcheck/          # Microservice: Brew order validation (Kafka consumer)
+├── ms-ingredientcheck/    # Microservice: Ingredient delivery validation (Kafka consumer)
+├── ms-brewmaster/         # Microservice: Brew orchestration (background worker)
 ├── agent-orchestrator/  # AI Agent: Main coordinator
 ├── agent-logs/          # AI Agent: Loki log analysis
 ├── agent-metrics/       # AI Agent: Mimir metrics analysis

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,10 +8,10 @@ This project is a **personal learning lab** built in layers, each added as a new
 ┌─────────────────────────────────────────────────────────┐
 │  BUSINESS LAYER (stable)                                │
 │                                                         │
-│  ms-customer ──┐               ┌── ms-ordercheck ── ms-order ─┤
-│                ├── Kafka ──────┤                             ├── PostgreSQL
-│  ms-supplier ──┘               └── ms-suppliercheck─ ms-stock─┤
-│                  ms-ordermanagement (background worker)       │
+│  ms-brewer  ──┐               ┌── ms-brewcheck     ── ms-brewery ─┤
+│               ├── Kafka ──────┤                               ├── PostgreSQL
+│  ms-supplier ─┘               └── ms-ingredientcheck─ ms-cellar─┤
+│                  ms-brewmaster (background worker)               │
 └─────────────────────────┬───────────────────────────────┘
                           │ OTLP
                           ▼
@@ -39,13 +39,13 @@ This project is a **personal learning lab** built in layers, each added as a new
 
 | Service | Role | Tech |
 |---------|------|------|
-| `ms-customer` | Generates orders → Kafka | Kafka producer |
-| `ms-supplier` | Generates stock updates → Kafka | Kafka producer |
-| `ms-ordercheck` | Validates & forwards orders | Kafka consumer → REST |
-| `ms-suppliercheck` | Validates & forwards stock updates | Kafka consumer → REST |
-| `ms-order` | Order management API | Flask + PostgreSQL |
-| `ms-stock` | Stock management API | Flask + PostgreSQL |
-| `ms-ordermanagement` | Processes registered orders, updates stock | Background worker |
+| `ms-brewer` | Generates brew orders → Kafka (`brew-orders`) | Kafka producer |
+| `ms-supplier` | Generates ingredient deliveries → Kafka (`ingredient-deliveries`) | Kafka producer |
+| `ms-brewcheck` | Validates & forwards brew orders to ms-brewery | Kafka consumer → REST |
+| `ms-ingredientcheck` | Validates & forwards ingredient deliveries to ms-cellar | Kafka consumer → REST |
+| `ms-brewery` | Brew management API | Flask + PostgreSQL |
+| `ms-cellar` | Ingredient stock management API | Flask + PostgreSQL |
+| `ms-brewmaster` | Fetches registered brews, consumes ingredients, updates brew status | Background worker |
 | `lib-models` | Shared business models | Pydantic |
 | `lib-ai` | Shared AI utilities (LLM config, MCP client) | LangChain |
 | `config` | Infrastructure configuration files | YAML |


### PR DESCRIPTION
## Summary

Closes #111

- **Root CLAUDE.md**: update KEEPER services table, Framework Convention, Error Injection, Infrastructure Access; add `compose-reset` to Key Task Targets; fix `HEALTHCHECK_SERVICES` comment (`ms-order`/`ms-stock` → `ms-brewery`/`ms-cellar`)
- **README.md**: update architecture diagram and project structure for brewery services
- **docs/architecture.md**: update ASCII diagram and services table for brewery domain
- **GETTING_STARTED.md**: add `task compose-reset` to Common Commands, update log example service name

> **Note:** per-service CLAUDE.md files were already updated in their respective rename PRs (#118–#123). This PR covers the project-wide docs.

## Test plan

- [ ] No references to `ms-customer`, `ms-order`, `ms-stock`, `ms-ordercheck`, `ms-suppliercheck`, `ms-ordermanagement` remain in updated docs
- [ ] `compose-reset` is documented in both GETTING_STARTED.md and root CLAUDE.md