### PR TITLE
fix(infra): increase healthcheck start_period and retries for ms-brewery and ms-cellar

### DIFF
--- a/docker-compose/docker-compose-apps.yml
+++ b/docker-compose/docker-compose-apps.yml
@@ -74,8 +74,8 @@ services:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5000/health')"]
       interval: 30s
       timeout: 5s
-      retries: 3
-      start_period: 10s
+      retries: 5
+      start_period: 20s
     restart: unless-stopped
     networks:
       - otel-network
@@ -96,8 +96,8 @@ services:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5001/health')"]
       interval: 30s
       timeout: 5s
-      retries: 3
-      start_period: 10s
+      retries: 5
+      start_period: 20s
     restart: unless-stopped
     networks:
       - otel-network


### PR DESCRIPTION
## Summary

- `start_period`: 10s → 20s on ms-brewery and ms-cellar
- `retries`: 3 → 5 on both services

## Why

On cold `compose-reset` with fresh volumes, Flask + SQLAlchemy startup and DB table creation can exceed 10s on slow disks or rootless Podman. The previous values caused false unhealthy status on first boot, blocking ms-brewcheck, ms-ingredientcheck, and ms-brewmaster from starting (they depend on `service_healthy`).

## Test plan

- [ ] `task compose-reset` — verify ms-brewery and ms-cellar reach `healthy` before dependent services start
- [ ] `task test-integration` — confirm both services report healthy