### PR TITLE
fix(ms-brewery): fix Dockerfile COPY path after module rename (order → brewery)

### DIFF
--- a/ms-brewery/Dockerfile
+++ b/ms-brewery/Dockerfile
@@ -21,7 +21,7 @@ RUN pip install --no-cache-dir uv && \
     uv run --no-dev python -m ensurepip && \
     uv run --no-dev opentelemetry-bootstrap -a install
 
-COPY ms-brewery/order /app/ms-brewery/order/
+COPY ms-brewery/brewery /app/ms-brewery/brewery/
 
 RUN chown -R appuser:appuser /app
 


### PR DESCRIPTION
## Summary

- Fix `COPY ms-brewery/order` → `COPY ms-brewery/brewery` in `ms-brewery/Dockerfile`

## Why

Residual from the brewery-phase-1 domain migration: the module directory was renamed from `order` to `brewery` but the Dockerfile `COPY` instruction was not updated. This caused `ms-brewery` to fail building entirely on a fresh stack (`compose-reset`), discovered during post-merge validation.

## Test plan

- [x] `task compose-up` — ms-brewery builds and starts successfully
- [x] `ms-brewery` reaches `healthy` status (healthcheck on `/health`)