### PR TITLE
fix(quality): resolve deferred issues #145, #146, #148

### DIFF
--- a/ms-beerstock/beerstock/routes/beerstock.py
+++ b/ms-beerstock/beerstock/routes/beerstock.py
@@ -234,6 +234,7 @@ def ship_beer_stock_route():
         db.commit()
         db_stock = get_beer_stock_by_style(db, brew_style=ship_data.brew_style)  # type: ignore[arg-type]
         if db_stock is None:
+            current_app.logger.error("Invariant violation: stock not found after ship for brew_style=%s", ship_data.brew_style)
             return jsonify({"error": "Internal error: stock not found after update"}), 500
         return jsonify(db_stock.to_dict()), 200
     except InsufficientBeerStockError as e:

--- a/ms-beerstock/beerstock/routes/beerstock.py
+++ b/ms-beerstock/beerstock/routes/beerstock.py
@@ -233,7 +233,8 @@ def ship_beer_stock_route():
         ship_beer_stock(db, brew_style=ship_data.brew_style, quantity=ship_data.quantity)
         db.commit()
         db_stock = get_beer_stock_by_style(db, brew_style=ship_data.brew_style)  # type: ignore[arg-type]
-        assert db_stock is not None  # guaranteed: ship_beer_stock() raises before reaching here
+        if db_stock is None:
+            return jsonify({"error": "Internal error: stock not found after update"}), 500
         return jsonify(db_stock.to_dict()), 200
     except InsufficientBeerStockError as e:
         return jsonify({"error": str(e)}), 400

--- a/ms-beerstock/pyproject.toml
+++ b/ms-beerstock/pyproject.toml
@@ -30,5 +30,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-brewcheck/brewcheck/brewcheck_consumer.py
+++ b/ms-brewcheck/brewcheck/brewcheck_consumer.py
@@ -132,7 +132,7 @@ def consume_messages():
                 elif err.code() == KafkaError.UNKNOWN_TOPIC_OR_PART:
                     logger.warning("Topic not available yet, retrying in 5s...")
                     time.sleep(5)
-                elif err:
+                else:
                     raise KafkaException(err)
             else:
                 _process_message(msg, ERROR_RATE)

--- a/ms-brewcheck/pyproject.toml
+++ b/ms-brewcheck/pyproject.toml
@@ -29,5 +29,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-brewer/pyproject.toml
+++ b/ms-brewer/pyproject.toml
@@ -27,5 +27,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-brewery/pyproject.toml
+++ b/ms-brewery/pyproject.toml
@@ -31,5 +31,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-brewmaster/pyproject.toml
+++ b/ms-brewmaster/pyproject.toml
@@ -27,5 +27,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-cellar/cellar/routes/cellar.py
+++ b/ms-cellar/cellar/routes/cellar.py
@@ -240,7 +240,8 @@ def decrease_ingredient_route():
         decrease_ingredient_quantity(db, ingredient_type=ingredient_data.ingredient_type, quantity=ingredient_data.quantity)
         db.commit()
         db_ingredient = get_ingredient_by_type(db, ingredient_type=ingredient_data.ingredient_type)  # type: ignore[arg-type]
-        assert db_ingredient is not None  # guaranteed: decrease_ingredient_quantity() raises before reaching here
+        if db_ingredient is None:
+            return jsonify({"error": "Internal error: ingredient not found after update"}), 500
         return jsonify(db_ingredient.to_dict()), 200
     except IngredientNotFoundError as e:
         return jsonify({"error": str(e)}), 404

--- a/ms-cellar/cellar/routes/cellar.py
+++ b/ms-cellar/cellar/routes/cellar.py
@@ -241,6 +241,7 @@ def decrease_ingredient_route():
         db.commit()
         db_ingredient = get_ingredient_by_type(db, ingredient_type=ingredient_data.ingredient_type)  # type: ignore[arg-type]
         if db_ingredient is None:
+            current_app.logger.error("Invariant violation: ingredient not found after decrease for type=%s", ingredient_data.ingredient_type)
             return jsonify({"error": "Internal error: ingredient not found after update"}), 500
         return jsonify(db_ingredient.to_dict()), 200
     except IngredientNotFoundError as e:

--- a/ms-cellar/pyproject.toml
+++ b/ms-cellar/pyproject.toml
@@ -30,5 +30,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-fermentation/pyproject.toml
+++ b/ms-fermentation/pyproject.toml
@@ -26,5 +26,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-ingredientcheck/ingredientcheck/ingredientcheck_consumer.py
+++ b/ms-ingredientcheck/ingredientcheck/ingredientcheck_consumer.py
@@ -132,7 +132,7 @@ def consume_messages():
                 elif err.code() == KafkaError.UNKNOWN_TOPIC_OR_PART:
                     logger.warning("Topic not available yet, retrying in 5s...")
                     time.sleep(5)
-                elif err:
+                else:
                     raise KafkaException(err)
             else:
                 _process_message(msg, ERROR_RATE)

--- a/ms-ingredientcheck/pyproject.toml
+++ b/ms-ingredientcheck/pyproject.toml
@@ -28,5 +28,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-quality-control/pyproject.toml
+++ b/ms-quality-control/pyproject.toml
@@ -28,5 +28,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-quality-control/quality_control/quality_consumer.py
+++ b/ms-quality-control/quality_control/quality_consumer.py
@@ -149,7 +149,7 @@ def consume_messages():
                 elif err.code() == KafkaError.UNKNOWN_TOPIC_OR_PART:
                     logger.warning("Topic not available yet, retrying in 5s...")
                     time.sleep(5)
-                elif err:
+                else:
                     raise KafkaException(err)
             else:
                 _process_message(msg, REJECT_RATE, ERROR_RATE)

--- a/ms-retailer/pyproject.toml
+++ b/ms-retailer/pyproject.toml
@@ -27,5 +27,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]

--- a/ms-supplier/pyproject.toml
+++ b/ms-supplier/pyproject.toml
@@ -27,5 +27,5 @@ venv = ".venv"
 venvPath = "."
 pythonVersion = "3.14"
 typeCheckingMode = "basic"
-extraPaths = ["../lib-models"]
+extraPaths = ["../lib-models"]  # assumes service sits at depth-1 under repo root
 exclude = ["**/.venv", "**/__pycache__"]


### PR DESCRIPTION
## Summary

- **#145**: replace `assert db_* is not None` with explicit `if … return 500` guard in `ms-beerstock` and `ms-cellar` route handlers — safe under Python `-O` flag
- **#146**: replace tautological `elif err:` with `else:` in Kafka error dispatch loop in `ms-brewcheck`, `ms-ingredientcheck`, `ms-quality-control`
- **#148**: add inline comment on `extraPaths = ["../lib-models"]` in all 11 KEEPER `pyproject.toml` documenting the depth-1 assumption

## Test plan

- [ ] `task test` passes (test-lint → test-unit)
- [ ] `task typecheck` passes (pyright on all KEEPER services)

Closes #145, #146, #148