### PR TITLE
chore(health): add container healthchecks to all KEEPER services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ task --list           # Show all available tasks with descriptions
 
 > **Taskfile variable scopes:** `PROJECTS` = all services (see `Taskfile.yml` for the full list), used by `task lint`.
 > `KEEPER_SERVICES` (12 dirs) = business services with runnable processes, used by `task test-lint` and `task test-unit`.
-> `HEALTHCHECK_SERVICES` (4 dirs) = `ms-brewery`, `ms-cellar`, `ms-beerstock` (Flask/HTTP healthcheck), `ms-dispatch` (process healthcheck via `/proc`) — used by the `test-integration` health loop.
+> `HEALTHCHECK_SERVICES` (12 dirs) = `ms-brewery`, `ms-cellar`, `ms-beerstock` (Flask/HTTP healthcheck), all other KEEPER services (process healthcheck via `/proc`) — used by the `test-integration` health loop.
 > Agent services (`agent-*`) and shared libs (`lib-*`) are in `PROJECTS` but not `KEEPER_SERVICES`.
 
 ## Environment Setup

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -22,9 +22,9 @@ vars:
 
   # Subset with a container healthcheck defined in docker-compose-apps.yml.
   # Flask REST APIs: ms-brewery, ms-cellar, ms-beerstock (urllib.request health endpoint).
-  # Kafka consumers: ms-dispatch (grep /proc/*/cmdline for running process).
+  # Kafka producers/consumers + background workers: grep /proc/*/cmdline for running process.
   # WARNING: only add a service here if docker-compose-apps.yml defines a HEALTHCHECK for it.
-  HEALTHCHECK_SERVICES: ms-brewery ms-cellar ms-beerstock ms-dispatch
+  HEALTHCHECK_SERVICES: ms-brewery ms-cellar ms-beerstock ms-dispatch ms-brewer ms-retailer ms-supplier ms-brewcheck ms-ingredientcheck ms-quality-control ms-brewmaster ms-fermentation
 
   # Ollama models to pull
   MODELS: mistral:7b llama3.2:3b qwen3:0.6b granite4:3b mistral-nemo:12b qwen2.5:7b phi4:14b

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,8 +21,9 @@ vars:
   KEEPER_SERVICES: ms-brewer ms-brewery ms-brewcheck ms-brewmaster ms-beerstock ms-cellar ms-dispatch ms-fermentation ms-quality-control ms-retailer ms-supplier ms-ingredientcheck
 
   # Subset with a container healthcheck defined in docker-compose-apps.yml.
-  # Flask REST APIs: ms-brewery, ms-cellar, ms-beerstock (urllib.request health endpoint).
-  # Kafka producers/consumers + background workers: grep /proc/*/cmdline for running process.
+  # Flask REST APIs (urllib.request): ms-brewery, ms-cellar, ms-beerstock.
+  # Process check (grep /proc/*/cmdline): ms-dispatch, ms-brewer, ms-retailer, ms-supplier,
+  #   ms-brewcheck, ms-ingredientcheck, ms-quality-control, ms-brewmaster, ms-fermentation.
   # WARNING: only add a service here if docker-compose-apps.yml defines a HEALTHCHECK for it.
   HEALTHCHECK_SERVICES: ms-brewery ms-cellar ms-beerstock ms-dispatch ms-brewer ms-retailer ms-supplier ms-brewcheck ms-ingredientcheck ms-quality-control ms-brewmaster ms-fermentation
 

--- a/docker-compose/docker-compose-apps.yml
+++ b/docker-compose/docker-compose-apps.yml
@@ -37,6 +37,12 @@ services:
       OTEL_SERVICE_NAME: ms-brewer
       KAFKA_BOOTSTRAP_SERVERS: broker:29092
       INTERVAL_SECONDS: 5
+    healthcheck:
+      test: ["CMD-SHELL", "grep -rl brewer_producer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - otel-network
@@ -54,6 +60,12 @@ services:
       OTEL_SERVICE_NAME: ms-retailer
       KAFKA_BOOTSTRAP_SERVERS: broker:29092
       INTERVAL_SECONDS: 10
+    healthcheck:
+      test: ["CMD-SHELL", "grep -rl retailer_producer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - otel-network
@@ -71,6 +83,12 @@ services:
       OTEL_SERVICE_NAME: ms-supplier
       KAFKA_BOOTSTRAP_SERVERS: broker:29092
       INTERVAL_SECONDS: 5
+    healthcheck:
+      test: ["CMD-SHELL", "grep -rl supplier_producer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - otel-network
@@ -136,6 +154,12 @@ services:
     depends_on:
       ms-brewery:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "grep -rl brewcheck_consumer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - otel-network
@@ -156,6 +180,12 @@ services:
     depends_on:
       ms-cellar:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "grep -rl ingredientcheck_consumer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - otel-network
@@ -179,6 +209,12 @@ services:
         condition: service_healthy
       ms-cellar:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "grep -rl brewmaster /proc/*/cmdline 2>/dev/null | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - otel-network
@@ -248,6 +284,12 @@ services:
     depends_on:
       ms-brewery:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "grep -rl quality_consumer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - otel-network
@@ -269,6 +311,12 @@ services:
     depends_on:
       ms-brewery:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "grep -rl fermentation_worker /proc/*/cmdline 2>/dev/null | grep -q ."]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
     restart: unless-stopped
     networks:
       - otel-network

--- a/docker-compose/docker-compose-apps.yml
+++ b/docker-compose/docker-compose-apps.yml
@@ -38,7 +38,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: broker:29092
       INTERVAL_SECONDS: 5
     healthcheck:
-      test: ["CMD-SHELL", "grep -rl brewer_producer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      test: ["CMD-SHELL", "grep -rq brewer_producer /proc/*/cmdline 2>/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -61,7 +61,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: broker:29092
       INTERVAL_SECONDS: 10
     healthcheck:
-      test: ["CMD-SHELL", "grep -rl retailer_producer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      test: ["CMD-SHELL", "grep -rq retailer_producer /proc/*/cmdline 2>/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -84,7 +84,7 @@ services:
       KAFKA_BOOTSTRAP_SERVERS: broker:29092
       INTERVAL_SECONDS: 5
     healthcheck:
-      test: ["CMD-SHELL", "grep -rl supplier_producer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      test: ["CMD-SHELL", "grep -rq supplier_producer /proc/*/cmdline 2>/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -155,7 +155,7 @@ services:
       ms-brewery:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "grep -rl brewcheck_consumer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      test: ["CMD-SHELL", "grep -rq brewcheck_consumer /proc/*/cmdline 2>/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -181,7 +181,7 @@ services:
       ms-cellar:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "grep -rl ingredientcheck_consumer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      test: ["CMD-SHELL", "grep -rq ingredientcheck_consumer /proc/*/cmdline 2>/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -210,7 +210,7 @@ services:
       ms-cellar:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "grep -rl brewmaster /proc/*/cmdline 2>/dev/null | grep -q ."]
+      test: ["CMD-SHELL", "grep -rq brewmaster.py /proc/*/cmdline 2>/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -258,7 +258,7 @@ services:
       ms-beerstock:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "grep -rl dispatch_consumer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      test: ["CMD-SHELL", "grep -rq dispatch_consumer /proc/*/cmdline 2>/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -285,7 +285,7 @@ services:
       ms-brewery:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "grep -rl quality_consumer /proc/*/cmdline 2>/dev/null | grep -q ."]
+      test: ["CMD-SHELL", "grep -rq quality_consumer /proc/*/cmdline 2>/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -312,7 +312,7 @@ services:
       ms-brewery:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "grep -rl fermentation_worker /proc/*/cmdline 2>/dev/null | grep -q ."]
+      test: ["CMD-SHELL", "grep -rq fermentation_worker /proc/*/cmdline 2>/dev/null"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
Closes #152

## Summary

- Add `/proc`-based healthchecks to the 8 KEEPER services that lacked them: `ms-brewer`, `ms-retailer`, `ms-supplier`, `ms-brewcheck`, `ms-ingredientcheck`, `ms-brewmaster`, `ms-quality-control`, `ms-fermentation`
- Expand `HEALTHCHECK_SERVICES` in `Taskfile.yml` from 4 → 12 services so `task test-integration` covers the full business layer
- Update `CLAUDE.md` comment to reflect the new count

## Pattern

Follows the `/proc` healthcheck established by `ms-dispatch` in #151:
```yaml
healthcheck:
  test: ["CMD-SHELL", "grep -rl <module_name> /proc/*/cmdline 2>/dev/null | grep -q ."]
  interval: 30s
  timeout: 5s
  retries: 3
  start_period: 30s
```

## Test plan

- [ ] `task test` passes (lint + unit)
- [ ] `task compose-reset` then `task test-integration` — all 12 KEEPER services report healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)